### PR TITLE
chore: replace extension icons with svg assets

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+node_modules/
+.DS_Store
+*.log
+/dist
+/build

--- a/README.md
+++ b/README.md
@@ -1,2 +1,38 @@
 # RollQueue
-A Firefox extension to manage a queue of Crunchyroll episodes, especially between different animes.
+
+RollQueue is a Firefox WebExtension that builds a performant queueing and playback companion for Crunchyroll. It keeps track of episodes you want to watch next, offers quick language and playback controls, and injects queue actions directly onto Crunchyroll episode cards.
+
+## Features
+
+- **Queue management** – add single episodes or whole upcoming runs from the Crunchyroll UI, drag & drop to reorder, and open items directly from the popup.
+- **Playback awareness** – content scripts monitor the Crunchyroll player and keep the extension aware of whether the current episode is playing, paused, or finished.
+- **Audio language control** – choose between the most common Crunchyroll audio language tracks for the queue or individual episodes.
+- **Smart cleanup** – optionally remove items from the queue once the episode ends.
+- **Debug friendly** – surface queue state, export/import helpers, and a one-click debug info dump for troubleshooting.
+
+## Getting started
+
+1. Run `npm install` if you plan to add tooling (none is required for the vanilla extension bundle).
+2. Open `about:debugging` in Firefox and choose **This Firefox**.
+3. Click **Load Temporary Add-on…** and select the repository's `manifest.json`.
+4. Navigate to a Crunchyroll episode list to try the injected menu items, or open the extension popup to manage your queue.
+
+## Project structure
+
+```
+manifest.json          # Extension manifest
+src/
+  background.js        # Service worker managing queue state
+  content.js           # Injects menu items and monitors playback
+  content.css          # Menu styling to match Crunchyroll UI
+  popup.html/css/js    # Queue UI, drag & drop, playback controls
+  options.html/css/js  # Advanced settings and queue import/export
+  constants.js         # Shared enums and defaults
+assets/                # Extension icons
+```
+
+## Development tips
+
+- Background, popup, and options scripts share constants via ES modules.
+- Content scripts dynamically annotate Crunchyroll episode cards to ensure menu actions receive rich metadata.
+- Debug logging can be toggled from the popup or options page if you need to inspect state transitions.

--- a/assets/icon-128.svg
+++ b/assets/icon-128.svg
@@ -1,0 +1,21 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="128" height="128" viewBox="0 0 128 128">
+  <defs>
+    <linearGradient id="queueGradient128" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#ff914d" />
+      <stop offset="100%" stop-color="#ff4d6d" />
+    </linearGradient>
+    <filter id="shadow" x="-10%" y="-10%" width="120%" height="120%" filterUnits="objectBoundingBox">
+      <feDropShadow dx="0" dy="4" stdDeviation="4" flood-color="rgba(0,0,0,0.25)" />
+    </filter>
+  </defs>
+  <rect x="12" y="12" width="104" height="104" rx="28" fill="url(#queueGradient128)" filter="url(#shadow)" />
+  <g fill="none" stroke="#ffffff" stroke-linecap="round" stroke-linejoin="round">
+    <path d="M44 48h48" stroke-width="8" />
+    <path d="M44 68h38" stroke-width="8" opacity="0.85" />
+    <path d="M44 88h28" stroke-width="8" opacity="0.7" />
+    <circle cx="36" cy="48" r="5" fill="#ffffff" stroke-width="6" />
+    <circle cx="36" cy="68" r="5" fill="#ffffff" stroke-width="6" opacity="0.85" />
+    <circle cx="36" cy="88" r="5" fill="#ffffff" stroke-width="6" opacity="0.7" />
+  </g>
+  <path d="M84 64l22 12-22 12z" fill="#ffffff" opacity="0.92" />
+</svg>

--- a/assets/icon-48.svg
+++ b/assets/icon-48.svg
@@ -1,0 +1,18 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="48" height="48" viewBox="0 0 48 48">
+  <defs>
+    <linearGradient id="queueGradient48" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#ff914d" />
+      <stop offset="100%" stop-color="#ff4d6d" />
+    </linearGradient>
+  </defs>
+  <rect x="4" y="4" width="40" height="40" rx="10" fill="url(#queueGradient48)" />
+  <g fill="none" stroke="#ffffff" stroke-linecap="round" stroke-linejoin="round">
+    <path d="M16 17h16" stroke-width="3" />
+    <path d="M16 24h12" stroke-width="3" opacity="0.85" />
+    <path d="M16 31h8" stroke-width="3" opacity="0.7" />
+    <circle cx="14" cy="17" r="1.5" fill="#ffffff" stroke-width="2" />
+    <circle cx="14" cy="24" r="1.5" fill="#ffffff" stroke-width="2" opacity="0.85" />
+    <circle cx="14" cy="31" r="1.5" fill="#ffffff" stroke-width="2" opacity="0.7" />
+  </g>
+  <path d="M30 23l8 5-8 5z" fill="#ffffff" opacity="0.9" />
+</svg>

--- a/manifest.json
+++ b/manifest.json
@@ -1,0 +1,40 @@
+{
+  "manifest_version": 3,
+  "name": "RollQueue",
+  "version": "0.1.0",
+  "description": "Queue Crunchyroll episodes, control playback, and manage audio languages directly from the browser.",
+  "permissions": [
+    "storage",
+    "tabs"
+  ],
+  "host_permissions": [
+    "*://www.crunchyroll.com/*"
+  ],
+  "background": {
+    "service_worker": "src/background.js",
+    "type": "module"
+  },
+  "action": {
+    "default_popup": "src/popup.html",
+    "default_icon": {
+      "48": "assets/icon-48.svg",
+      "128": "assets/icon-128.svg"
+    }
+  },
+  "options_ui": {
+    "page": "src/options.html",
+    "open_in_tab": true
+  },
+  "icons": {
+    "48": "assets/icon-48.svg",
+    "128": "assets/icon-128.svg"
+  },
+  "content_scripts": [
+    {
+      "matches": ["*://www.crunchyroll.com/*"],
+      "js": ["src/content.js"],
+      "css": ["src/content.css"],
+      "run_at": "document_idle"
+    }
+  ]
+}

--- a/src/background.js
+++ b/src/background.js
@@ -1,0 +1,217 @@
+import {
+  AUDIO_LANGUAGES,
+  DEFAULT_SETTINGS,
+  MESSAGE_TYPES,
+  PLAYBACK_STATES,
+  STORAGE_KEYS
+} from './constants.js';
+
+const browserApi = typeof browser !== 'undefined' ? browser : chrome;
+
+let state = {
+  queue: [],
+  currentEpisodeId: null,
+  playbackState: PLAYBACK_STATES.IDLE,
+  settings: { ...DEFAULT_SETTINGS },
+  lastUpdated: Date.now()
+};
+
+const persistState = async () => {
+  await browserApi.storage.local.set({
+    [STORAGE_KEYS.STATE]: state
+  });
+};
+
+const loadState = async () => {
+  const stored = await browserApi.storage.local.get(STORAGE_KEYS.STATE);
+  if (stored && stored[STORAGE_KEYS.STATE]) {
+    const storedState = stored[STORAGE_KEYS.STATE];
+    state = {
+      queue: storedState.queue ?? [],
+      currentEpisodeId: storedState.currentEpisodeId ?? null,
+      playbackState: storedState.playbackState ?? PLAYBACK_STATES.IDLE,
+      settings: { ...DEFAULT_SETTINGS, ...(storedState.settings || {}) },
+      lastUpdated: storedState.lastUpdated ?? Date.now()
+    };
+  } else {
+    await persistState();
+  }
+};
+
+const debugLog = (...args) => {
+  if (state.settings.debugLogging) {
+    console.debug('[RollQueue]', ...args);
+  }
+};
+
+const broadcastState = async () => {
+  state.lastUpdated = Date.now();
+  await persistState();
+  debugLog('Broadcasting state', state);
+  browserApi.runtime.sendMessage({
+    type: MESSAGE_TYPES.STATE_UPDATED,
+    payload: state
+  }).catch(() => {
+    // No active listeners.
+  });
+};
+
+const findEpisodeIndex = (episodeId) => state.queue.findIndex((item) => item.id === episodeId);
+
+const ensureAudioLanguage = (episode) => ({
+  ...episode,
+  audioLanguage: episode.audioLanguage || state.settings.defaultAudioLanguage
+});
+
+const addEpisodes = async (episodes) => {
+  let added = false;
+  episodes.forEach((rawEpisode) => {
+    const episode = ensureAudioLanguage(rawEpisode);
+    if (findEpisodeIndex(episode.id) === -1) {
+      state.queue.push({ ...episode, addedAt: Date.now() });
+      added = true;
+    }
+  });
+  if (added) {
+    await broadcastState();
+  }
+  return added;
+};
+
+const removeEpisode = async (episodeId) => {
+  const index = findEpisodeIndex(episodeId);
+  if (index !== -1) {
+    const [removed] = state.queue.splice(index, 1);
+    debugLog('Removed episode', removed);
+    if (state.currentEpisodeId === episodeId) {
+      state.currentEpisodeId = null;
+      state.playbackState = PLAYBACK_STATES.IDLE;
+    }
+    await broadcastState();
+  }
+};
+
+const reorderQueue = async (orderedIds) => {
+  const newQueue = [];
+  orderedIds.forEach((id) => {
+    const item = state.queue.find((episode) => episode.id === id);
+    if (item) {
+      newQueue.push(item);
+    }
+  });
+  // Append any episodes that weren't included to preserve queue.
+  state.queue.forEach((episode) => {
+    if (!orderedIds.includes(episode.id)) {
+      newQueue.push(episode);
+    }
+  });
+  state.queue = newQueue;
+  await broadcastState();
+};
+
+const setCurrentEpisode = async (episodeId) => {
+  if (episodeId && findEpisodeIndex(episodeId) === -1) {
+    debugLog('Attempted to select unknown episode', episodeId);
+    return;
+  }
+  state.currentEpisodeId = episodeId;
+  await broadcastState();
+};
+
+const setPlaybackState = async (playbackState) => {
+  state.playbackState = playbackState;
+  if (
+    playbackState === PLAYBACK_STATES.ENDED &&
+    state.settings.autoRemoveCompleted &&
+    state.currentEpisodeId
+  ) {
+    await removeEpisode(state.currentEpisodeId);
+  } else {
+    await broadcastState();
+  }
+};
+
+const updateSettings = async (settingsUpdate) => {
+  state.settings = {
+    ...state.settings,
+    ...settingsUpdate
+  };
+  if (settingsUpdate.defaultAudioLanguage) {
+    state.queue = state.queue.map((episode) => ({
+      ...episode,
+      audioLanguage: episode.audioLanguage || state.settings.defaultAudioLanguage
+    }));
+  }
+  await broadcastState();
+};
+
+const setAudioLanguage = async (episodeId, audioLanguage) => {
+  const index = findEpisodeIndex(episodeId);
+  if (index !== -1) {
+    state.queue[index] = {
+      ...state.queue[index],
+      audioLanguage
+    };
+    await broadcastState();
+  }
+};
+
+const setQueue = async (episodes) => {
+  state.queue = episodes.map((episode) => ensureAudioLanguage(episode));
+  await broadcastState();
+};
+
+const handleMessage = async (message) => {
+  switch (message.type) {
+    case MESSAGE_TYPES.GET_STATE:
+      return state;
+    case MESSAGE_TYPES.ADD_EPISODE:
+      await addEpisodes([message.payload]);
+      return state;
+    case MESSAGE_TYPES.ADD_EPISODE_AND_NEWER:
+      await addEpisodes(message.payload);
+      return state;
+    case MESSAGE_TYPES.REMOVE_EPISODE:
+      await removeEpisode(message.payload.id);
+      return state;
+    case MESSAGE_TYPES.REORDER_QUEUE:
+      await reorderQueue(message.payload.ids);
+      return state;
+    case MESSAGE_TYPES.SELECT_EPISODE:
+      await setCurrentEpisode(message.payload.id);
+      return state;
+    case MESSAGE_TYPES.UPDATE_PLAYBACK_STATE:
+      await setPlaybackState(message.payload.state);
+      return state;
+    case MESSAGE_TYPES.UPDATE_SETTINGS:
+      await updateSettings(message.payload.settings);
+      return state;
+    case MESSAGE_TYPES.SET_AUDIO_LANGUAGE:
+      await setAudioLanguage(message.payload.id, message.payload.audioLanguage);
+      return state;
+    case MESSAGE_TYPES.SET_QUEUE:
+      await setQueue(message.payload.queue);
+      return state;
+    case MESSAGE_TYPES.REQUEST_DEBUG_DUMP:
+      return {
+        timestamp: new Date().toISOString(),
+        audioLanguages: AUDIO_LANGUAGES,
+        state
+      };
+    default:
+      debugLog('Unknown message', message);
+  }
+  return state;
+};
+
+browserApi.runtime.onMessage.addListener((message, sender) => {
+  debugLog('Received message', message, sender?.tab?.id);
+  return handleMessage(message);
+});
+
+browserApi.runtime.onInstalled.addListener(async () => {
+  await loadState();
+  await broadcastState();
+});
+
+loadState().then(broadcastState);

--- a/src/constants.js
+++ b/src/constants.js
@@ -1,0 +1,42 @@
+export const AUDIO_LANGUAGES = [
+  { code: 'ja-JP', label: 'Japanese' },
+  { code: 'en-US', label: 'English' },
+  { code: 'es-419', label: 'Spanish (Latin America)' },
+  { code: 'es-ES', label: 'Spanish (Spain)' },
+  { code: 'pt-BR', label: 'Portuguese (Brazil)' },
+  { code: 'fr-FR', label: 'French' },
+  { code: 'de-DE', label: 'German' },
+  { code: 'it-IT', label: 'Italian' }
+];
+
+export const DEFAULT_SETTINGS = {
+  autoRemoveCompleted: true,
+  debugLogging: false,
+  defaultAudioLanguage: AUDIO_LANGUAGES[0].code
+};
+
+export const PLAYBACK_STATES = {
+  IDLE: 'idle',
+  PLAYING: 'playing',
+  PAUSED: 'paused',
+  ENDED: 'ended'
+};
+
+export const MESSAGE_TYPES = {
+  GET_STATE: 'GET_STATE',
+  STATE_UPDATED: 'STATE_UPDATED',
+  ADD_EPISODE: 'ADD_EPISODE',
+  ADD_EPISODE_AND_NEWER: 'ADD_EPISODE_AND_NEWER',
+  REMOVE_EPISODE: 'REMOVE_EPISODE',
+  REORDER_QUEUE: 'REORDER_QUEUE',
+  UPDATE_SETTINGS: 'UPDATE_SETTINGS',
+  SELECT_EPISODE: 'SELECT_EPISODE',
+  UPDATE_PLAYBACK_STATE: 'UPDATE_PLAYBACK_STATE',
+  REQUEST_DEBUG_DUMP: 'REQUEST_DEBUG_DUMP',
+  SET_AUDIO_LANGUAGE: 'SET_AUDIO_LANGUAGE',
+  SET_QUEUE: 'SET_QUEUE'
+};
+
+export const STORAGE_KEYS = {
+  STATE: 'rollQueueState'
+};

--- a/src/content.css
+++ b/src/content.css
@@ -1,0 +1,21 @@
+.rollqueue-menu-item {
+  list-style: none;
+}
+
+.rollqueue-menu-button {
+  width: 100%;
+  text-align: left;
+  background: none;
+  border: none;
+  padding: 0.75rem 1rem;
+  font: inherit;
+  color: inherit;
+  cursor: pointer;
+  border-radius: 0.5rem;
+}
+
+.rollqueue-menu-button:hover,
+.rollqueue-menu-button:focus {
+  background-color: rgba(255, 138, 0, 0.15);
+  outline: none;
+}

--- a/src/content.js
+++ b/src/content.js
@@ -1,0 +1,238 @@
+const browserApi = typeof browser !== 'undefined' ? browser : chrome;
+
+const MESSAGE_TYPES = {
+  GET_STATE: 'GET_STATE',
+  STATE_UPDATED: 'STATE_UPDATED',
+  ADD_EPISODE: 'ADD_EPISODE',
+  ADD_EPISODE_AND_NEWER: 'ADD_EPISODE_AND_NEWER',
+  REMOVE_EPISODE: 'REMOVE_EPISODE',
+  REORDER_QUEUE: 'REORDER_QUEUE',
+  UPDATE_SETTINGS: 'UPDATE_SETTINGS',
+  SELECT_EPISODE: 'SELECT_EPISODE',
+  UPDATE_PLAYBACK_STATE: 'UPDATE_PLAYBACK_STATE',
+  REQUEST_DEBUG_DUMP: 'REQUEST_DEBUG_DUMP',
+  SET_AUDIO_LANGUAGE: 'SET_AUDIO_LANGUAGE',
+  SET_QUEUE: 'SET_QUEUE'
+};
+
+const PLAYBACK_STATES = {
+  IDLE: 'idle',
+  PLAYING: 'playing',
+  PAUSED: 'paused',
+  ENDED: 'ended'
+};
+
+const MENU_ITEM_CLASS = 'rollqueue-menu-item';
+const MENU_ITEM_ATTRIBUTE = 'data-rollqueue-menu-item';
+const CARD_ATTRIBUTE = 'data-rollqueue-episode-id';
+const ANNOTATED_FLAG = 'data-rollqueue-annotated';
+
+const sendMessage = (message) => {
+  return browserApi.runtime.sendMessage(message).catch(() => undefined);
+};
+
+const parseEpisodeIdFromUrl = (url) => {
+  try {
+    const parsed = new URL(url, window.location.href);
+    const segments = parsed.pathname.split('/').filter(Boolean);
+    const watchIndex = segments.indexOf('watch');
+    if (watchIndex !== -1 && segments[watchIndex + 1]) {
+      return segments[watchIndex + 1];
+    }
+    return parsed.href;
+  } catch (error) {
+    console.warn('RollQueue: Unable to parse episode id', url, error);
+    return url;
+  }
+};
+
+const annotateEpisodeCards = () => {
+  document.querySelectorAll('a[href*="/watch/"]').forEach((anchor) => {
+    const card = anchor.closest('[data-testid="episode-card"], article, li, div');
+    if (!card || card.hasAttribute(ANNOTATED_FLAG)) {
+      return;
+    }
+    const id = parseEpisodeIdFromUrl(anchor.href);
+    const titleEl = card.querySelector('[data-testid="media-card-title"], h3, .text--primary, .card-title');
+    const subTitleEl = card.querySelector('[data-testid="media-card-subtitle"], .text--secondary');
+    const thumbImg = card.querySelector('img');
+    card.setAttribute(CARD_ATTRIBUTE, id);
+    card.setAttribute('data-rollqueue-episode-url', anchor.href);
+    card.setAttribute('data-rollqueue-episode-title', (titleEl?.textContent || anchor.textContent || '').trim());
+    if (subTitleEl) {
+      card.setAttribute('data-rollqueue-episode-subtitle', subTitleEl.textContent.trim());
+    }
+    if (thumbImg) {
+      card.setAttribute('data-rollqueue-episode-thumbnail', thumbImg.currentSrc || thumbImg.src);
+    }
+    card.setAttribute(ANNOTATED_FLAG, 'true');
+  });
+};
+
+const gatherEpisodesFromCard = (card, includeNewer = false) => {
+  if (!card) {
+    return [];
+  }
+  const container = card.parentElement;
+  const cards = container ? Array.from(container.querySelectorAll(`[${CARD_ATTRIBUTE}]`)) : [card];
+  const startIndex = cards.indexOf(card);
+  const selected = includeNewer && startIndex !== -1 ? cards.slice(startIndex) : [card];
+  return selected.map((episodeCard) => ({
+    id: episodeCard.getAttribute(CARD_ATTRIBUTE),
+    url: episodeCard.getAttribute('data-rollqueue-episode-url'),
+    title: episodeCard.getAttribute('data-rollqueue-episode-title'),
+    subtitle: episodeCard.getAttribute('data-rollqueue-episode-subtitle'),
+    thumbnail: episodeCard.getAttribute('data-rollqueue-episode-thumbnail')
+  }));
+};
+
+const createMenuItem = (label, onSelect) => {
+  const item = document.createElement('li');
+  item.setAttribute(MENU_ITEM_ATTRIBUTE, 'true');
+  item.classList.add(MENU_ITEM_CLASS);
+  item.setAttribute('role', 'menuitem');
+  const button = document.createElement('button');
+  button.type = 'button';
+  button.textContent = label;
+  button.className = 'rollqueue-menu-button';
+  button.addEventListener('click', (event) => {
+    event.preventDefault();
+    event.stopPropagation();
+    onSelect();
+    const menu = item.closest('[role="menu"], ul, ol');
+    if (menu) {
+      menu.dispatchEvent(new Event('rollqueue:close-menu', { bubbles: true }));
+    }
+  });
+  item.appendChild(button);
+  return item;
+};
+
+const injectMenuItems = (menu) => {
+  if (!(menu instanceof Element)) {
+    return;
+  }
+  if (menu.querySelector(`[${MENU_ITEM_ATTRIBUTE}]`)) {
+    return;
+  }
+  const card = menu.closest(`[${CARD_ATTRIBUTE}]`);
+  if (!card) {
+    return;
+  }
+  const addSingle = createMenuItem('Add to queue…', () => {
+    const episodes = gatherEpisodesFromCard(card, false);
+    if (episodes.length) {
+      sendMessage({
+        type: MESSAGE_TYPES.ADD_EPISODE,
+        payload: episodes[0]
+      });
+    }
+  });
+
+  const addSeries = createMenuItem('Add this and newer…', () => {
+    const episodes = gatherEpisodesFromCard(card, true);
+    if (episodes.length) {
+      sendMessage({
+        type: MESSAGE_TYPES.ADD_EPISODE_AND_NEWER,
+        payload: episodes
+      });
+    }
+  });
+
+  if (menu.firstChild) {
+    menu.insertBefore(addSeries, menu.firstChild);
+    menu.insertBefore(addSingle, menu.firstChild);
+  } else {
+    menu.appendChild(addSingle);
+    menu.appendChild(addSeries);
+  }
+};
+
+const menuObserver = new MutationObserver((mutations) => {
+  mutations.forEach((mutation) => {
+    mutation.addedNodes.forEach((node) => {
+      if (!(node instanceof Element)) {
+        return;
+      }
+      if (node.matches?.('[role="menu"], ul, ol')) {
+        injectMenuItems(node);
+      }
+      node.querySelectorAll?.('[role="menu"], ul, ol').forEach((child) => {
+        injectMenuItems(child);
+      });
+    });
+  });
+});
+
+const setupMenuInjection = () => {
+  annotateEpisodeCards();
+  document.querySelectorAll('[role="menu"], ul, ol').forEach((menu) => {
+    injectMenuItems(menu);
+  });
+  menuObserver.observe(document.body, { childList: true, subtree: true });
+};
+
+const updatePlaybackStatus = (state) => {
+  sendMessage({
+    type: MESSAGE_TYPES.UPDATE_PLAYBACK_STATE,
+    payload: { state }
+  });
+};
+
+const selectCurrentEpisode = (episodeId) => {
+  if (!episodeId) {
+    return;
+  }
+  sendMessage({
+    type: MESSAGE_TYPES.SELECT_EPISODE,
+    payload: { id: episodeId }
+  });
+};
+
+const monitorVideoElement = (video) => {
+  if (!video || video.dataset.rollqueueBound === 'true') {
+    return;
+  }
+  video.dataset.rollqueueBound = 'true';
+  updatePlaybackStatus(video.paused ? PLAYBACK_STATES.PAUSED : PLAYBACK_STATES.PLAYING);
+  const handlePlay = () => updatePlaybackStatus(PLAYBACK_STATES.PLAYING);
+  const handlePause = () => {
+    if (video.ended) {
+      updatePlaybackStatus(PLAYBACK_STATES.ENDED);
+    } else {
+      updatePlaybackStatus(PLAYBACK_STATES.PAUSED);
+    }
+  };
+  const handleEnded = () => updatePlaybackStatus(PLAYBACK_STATES.ENDED);
+  const handleLoaded = () => updatePlaybackStatus(PLAYBACK_STATES.IDLE);
+  video.addEventListener('play', handlePlay);
+  video.addEventListener('pause', handlePause);
+  video.addEventListener('ended', handleEnded);
+  video.addEventListener('loadeddata', handleLoaded);
+};
+
+const locateAndMonitorVideo = () => {
+  const video = document.querySelector('video');
+  if (video) {
+    monitorVideoElement(video);
+  }
+};
+
+const initCurrentEpisodeSelection = () => {
+  if (!window.location.pathname.includes('/watch/')) {
+    return;
+  }
+  const id = parseEpisodeIdFromUrl(window.location.href);
+  selectCurrentEpisode(id);
+};
+
+const scheduleTasks = () => {
+  annotateEpisodeCards();
+  locateAndMonitorVideo();
+  initCurrentEpisodeSelection();
+};
+
+scheduleTasks();
+setupMenuInjection();
+
+setInterval(scheduleTasks, 2000);

--- a/src/options.css
+++ b/src/options.css
@@ -1,0 +1,75 @@
+:root {
+  color-scheme: dark light;
+  font-family: 'Inter', 'Segoe UI', sans-serif;
+}
+
+body {
+  margin: 0;
+  background: #0f172a;
+  color: #f8fafc;
+}
+
+.container {
+  max-width: 720px;
+  margin: 0 auto;
+  padding: 2rem;
+  display: flex;
+  flex-direction: column;
+  gap: 2rem;
+}
+
+h1,
+h2 {
+  margin: 0;
+}
+
+section {
+  background: rgba(15, 23, 42, 0.85);
+  border-radius: 0.75rem;
+  padding: 1.5rem;
+  border: 1px solid rgba(255, 138, 0, 0.15);
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.setting {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  font-size: 1rem;
+}
+
+select {
+  padding: 0.75rem;
+  border-radius: 0.5rem;
+  border: 1px solid rgba(248, 250, 252, 0.1);
+  background: rgba(15, 23, 42, 0.8);
+  color: inherit;
+}
+
+button {
+  padding: 0.75rem 1rem;
+  border-radius: 0.5rem;
+  border: none;
+  background: rgba(255, 138, 0, 0.9);
+  color: #0f172a;
+  font-weight: 600;
+  cursor: pointer;
+  width: fit-content;
+}
+
+button:hover {
+  background: #ff8a00;
+}
+
+.state-dump {
+  max-height: 320px;
+  overflow: auto;
+  background: rgba(2, 6, 23, 0.6);
+  padding: 1rem;
+  border-radius: 0.5rem;
+  font-family: 'JetBrains Mono', 'Fira Code', monospace;
+  font-size: 0.875rem;
+  border: 1px solid rgba(255, 138, 0, 0.15);
+}

--- a/src/options.html
+++ b/src/options.html
@@ -1,0 +1,40 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>RollQueue Settings</title>
+    <link rel="stylesheet" href="options.css" />
+  </head>
+  <body>
+    <main class="container">
+      <h1>RollQueue Settings</h1>
+      <section>
+        <h2>Queue preferences</h2>
+        <label class="setting">
+          <input type="checkbox" id="auto-remove" />
+          Auto remove episodes once playback ends
+        </label>
+        <label class="setting">
+          <input type="checkbox" id="debug-logging" />
+          Enable debug logging
+        </label>
+      </section>
+      <section>
+        <h2>Default audio language</h2>
+        <select id="audio-language"></select>
+      </section>
+      <section>
+        <h2>Queue management</h2>
+        <button id="clear-queue">Clear queue</button>
+        <button id="export-queue">Export queue</button>
+        <button id="import-queue">Import queue</button>
+        <input type="file" id="queue-file" accept="application/json" hidden />
+      </section>
+      <section>
+        <h2>Status</h2>
+        <pre id="state-dump" class="state-dump"></pre>
+      </section>
+    </main>
+    <script type="module" src="options.js"></script>
+  </body>
+</html>

--- a/src/options.js
+++ b/src/options.js
@@ -1,0 +1,137 @@
+import {
+  AUDIO_LANGUAGES,
+  MESSAGE_TYPES,
+  DEFAULT_SETTINGS
+} from './constants.js';
+
+const browserApi = typeof browser !== 'undefined' ? browser : chrome;
+
+let state = {
+  queue: [],
+  currentEpisodeId: null,
+  playbackState: 'idle',
+  settings: { ...DEFAULT_SETTINGS },
+  lastUpdated: Date.now()
+};
+
+const autoRemoveCheckbox = document.getElementById('auto-remove');
+const debugLoggingCheckbox = document.getElementById('debug-logging');
+const audioLanguageSelect = document.getElementById('audio-language');
+const clearQueueButton = document.getElementById('clear-queue');
+const exportQueueButton = document.getElementById('export-queue');
+const importQueueButton = document.getElementById('import-queue');
+const queueFileInput = document.getElementById('queue-file');
+const stateDumpEl = document.getElementById('state-dump');
+
+const sendMessage = (message) => browserApi.runtime.sendMessage(message);
+
+const populateLanguages = () => {
+  AUDIO_LANGUAGES.forEach((language) => {
+    const option = document.createElement('option');
+    option.value = language.code;
+    option.textContent = `${language.label} (${language.code})`;
+    audioLanguageSelect.appendChild(option);
+  });
+};
+
+const renderState = () => {
+  autoRemoveCheckbox.checked = state.settings.autoRemoveCompleted;
+  debugLoggingCheckbox.checked = state.settings.debugLogging;
+  audioLanguageSelect.value = state.settings.defaultAudioLanguage;
+  stateDumpEl.textContent = JSON.stringify(state, null, 2);
+};
+
+const requestState = async () => {
+  const newState = await sendMessage({ type: MESSAGE_TYPES.GET_STATE });
+  if (newState) {
+    state = newState;
+    renderState();
+  }
+};
+
+autoRemoveCheckbox.addEventListener('change', () => {
+  sendMessage({
+    type: MESSAGE_TYPES.UPDATE_SETTINGS,
+    payload: { settings: { autoRemoveCompleted: autoRemoveCheckbox.checked } }
+  });
+});
+
+debugLoggingCheckbox.addEventListener('change', () => {
+  sendMessage({
+    type: MESSAGE_TYPES.UPDATE_SETTINGS,
+    payload: { settings: { debugLogging: debugLoggingCheckbox.checked } }
+  });
+});
+
+audioLanguageSelect.addEventListener('change', () => {
+  sendMessage({
+    type: MESSAGE_TYPES.UPDATE_SETTINGS,
+    payload: { settings: { defaultAudioLanguage: audioLanguageSelect.value } }
+  });
+});
+
+clearQueueButton.addEventListener('click', () => {
+  if (confirm('Clear the entire queue?')) {
+    sendMessage({
+      type: MESSAGE_TYPES.SET_QUEUE,
+      payload: { queue: [] }
+    });
+  }
+});
+
+const downloadJson = (filename, data) => {
+  const blob = new Blob([JSON.stringify(data, null, 2)], { type: 'application/json' });
+  const url = URL.createObjectURL(blob);
+  const anchor = document.createElement('a');
+  anchor.href = url;
+  anchor.download = filename;
+  document.body.appendChild(anchor);
+  anchor.click();
+  anchor.remove();
+  URL.revokeObjectURL(url);
+};
+
+exportQueueButton.addEventListener('click', async () => {
+  const currentState = await sendMessage({ type: MESSAGE_TYPES.GET_STATE });
+  if (currentState) {
+    downloadJson(`rollqueue-export-${Date.now()}.json`, currentState.queue);
+  }
+});
+
+importQueueButton.addEventListener('click', () => {
+  queueFileInput.click();
+});
+
+queueFileInput.addEventListener('change', async () => {
+  const [file] = queueFileInput.files;
+  if (!file) {
+    return;
+  }
+  const text = await file.text();
+  try {
+    const data = JSON.parse(text);
+    if (!Array.isArray(data)) {
+      throw new Error('Invalid queue format');
+    }
+    await sendMessage({
+      type: MESSAGE_TYPES.SET_QUEUE,
+      payload: { queue: data }
+    });
+    alert('Queue imported successfully');
+  } catch (error) {
+    console.error('Failed to import queue', error);
+    alert('Failed to import queue. Please make sure the file is valid.');
+  } finally {
+    queueFileInput.value = '';
+  }
+});
+
+browserApi.runtime.onMessage.addListener((message) => {
+  if (message.type === MESSAGE_TYPES.STATE_UPDATED) {
+    state = message.payload;
+    renderState();
+  }
+});
+
+populateLanguages();
+requestState();

--- a/src/popup.css
+++ b/src/popup.css
@@ -1,0 +1,186 @@
+:root {
+  color-scheme: dark light;
+  font-family: 'Inter', 'Segoe UI', sans-serif;
+}
+
+body {
+  margin: 0;
+  padding: 1rem;
+  width: 360px;
+  background: #0f172a;
+  color: #f8fafc;
+}
+
+.header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 1rem;
+}
+
+.header h1 {
+  font-size: 1.25rem;
+  margin: 0;
+}
+
+.status {
+  font-size: 0.875rem;
+  padding: 0.25rem 0.5rem;
+  border-radius: 999px;
+  background: rgba(255, 138, 0, 0.15);
+  color: #ff8a00;
+}
+
+.controls {
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: 0.75rem;
+  margin-bottom: 1rem;
+}
+
+.language-selector label {
+  display: block;
+  font-size: 0.75rem;
+  margin-bottom: 0.25rem;
+}
+
+.language-selector select {
+  width: 100%;
+  padding: 0.5rem;
+  border-radius: 0.5rem;
+  border: 1px solid rgba(248, 250, 252, 0.1);
+  background: rgba(15, 23, 42, 0.8);
+  color: inherit;
+}
+
+.playback-controls {
+  display: flex;
+  gap: 0.5rem;
+}
+
+.playback-controls button,
+.footer button {
+  flex: 1;
+  padding: 0.5rem;
+  border: none;
+  border-radius: 0.5rem;
+  background: rgba(255, 138, 0, 0.9);
+  color: #0f172a;
+  font-weight: 600;
+  cursor: pointer;
+}
+
+.playback-controls button:hover,
+.footer button:hover {
+  background: #ff8a00;
+}
+
+.queue-section {
+  margin-bottom: 1rem;
+}
+
+.queue-section h2,
+.settings h2 {
+  font-size: 1rem;
+  margin: 0 0 0.5rem 0;
+}
+
+.queue-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  max-height: 200px;
+  overflow-y: auto;
+}
+
+.queue-item {
+  display: grid;
+  grid-template-columns: auto 1fr auto;
+  gap: 0.5rem;
+  align-items: center;
+  padding: 0.5rem;
+  border-radius: 0.5rem;
+  background: rgba(15, 23, 42, 0.85);
+  border: 1px solid rgba(255, 138, 0, 0.1);
+  cursor: grab;
+}
+
+.queue-item.dragging {
+  opacity: 0.5;
+}
+
+.queue-item button {
+  padding: 0.35rem 0.75rem;
+  border-radius: 0.5rem;
+  border: 1px solid rgba(255, 138, 0, 0.3);
+  background: rgba(255, 138, 0, 0.15);
+  color: #ffb347;
+  font-weight: 600;
+  cursor: pointer;
+}
+
+.queue-item button:hover {
+  background: rgba(255, 138, 0, 0.3);
+}
+
+.queue-item img {
+  width: 64px;
+  height: 36px;
+  object-fit: cover;
+  border-radius: 0.375rem;
+}
+
+.queue-item .metadata {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+}
+
+.queue-item .title {
+  font-size: 0.875rem;
+  font-weight: 600;
+}
+
+.queue-item .subtitle {
+  font-size: 0.75rem;
+  color: rgba(248, 250, 252, 0.7);
+}
+
+.queue-item .language {
+  font-size: 0.75rem;
+  color: rgba(255, 138, 0, 0.9);
+}
+
+.queue-item.selected {
+  border-color: #ff8a00;
+  box-shadow: 0 0 0 2px rgba(255, 138, 0, 0.25);
+}
+
+.settings {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  margin-bottom: 1rem;
+}
+
+.setting {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  font-size: 0.875rem;
+}
+
+.footer {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+.footer .timestamp {
+  font-size: 0.75rem;
+  opacity: 0.75;
+}

--- a/src/popup.html
+++ b/src/popup.html
@@ -1,0 +1,45 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>RollQueue</title>
+    <link rel="stylesheet" href="popup.css" />
+  </head>
+  <body>
+    <header class="header">
+      <h1>RollQueue</h1>
+      <span class="status" id="playback-status">Idle</span>
+    </header>
+    <section class="controls">
+      <div class="language-selector">
+        <label for="audio-language">Audio language</label>
+        <select id="audio-language"></select>
+      </div>
+      <div class="playback-controls">
+        <button id="play-button" title="Play selected episode">Play</button>
+        <button id="pause-button" title="Pause playback">Pause</button>
+        <button id="remove-button" title="Remove selected episode">Remove</button>
+      </div>
+    </section>
+    <section class="queue-section">
+      <h2>Queue</h2>
+      <ul id="queue-list" class="queue-list"></ul>
+    </section>
+    <section class="settings">
+      <h2>Settings</h2>
+      <label class="setting">
+        <input type="checkbox" id="auto-remove" />
+        Auto remove episodes when completed
+      </label>
+      <label class="setting">
+        <input type="checkbox" id="debug-logging" />
+        Enable debug logging
+      </label>
+    </section>
+    <footer class="footer">
+      <button id="debug-dump">Copy debug info</button>
+      <span class="timestamp" id="last-updated"></span>
+    </footer>
+    <script type="module" src="popup.js"></script>
+  </body>
+</html>

--- a/src/popup.js
+++ b/src/popup.js
@@ -1,0 +1,268 @@
+import {
+  AUDIO_LANGUAGES,
+  MESSAGE_TYPES,
+  PLAYBACK_STATES,
+  DEFAULT_SETTINGS
+} from './constants.js';
+
+const browserApi = typeof browser !== 'undefined' ? browser : chrome;
+
+let appState = {
+  queue: [],
+  currentEpisodeId: null,
+  playbackState: PLAYBACK_STATES.IDLE,
+  settings: { ...DEFAULT_SETTINGS },
+  lastUpdated: Date.now()
+};
+
+let selectedEpisodeId = null;
+
+const queueList = document.getElementById('queue-list');
+const playbackStatus = document.getElementById('playback-status');
+const audioLanguageSelect = document.getElementById('audio-language');
+const autoRemoveCheckbox = document.getElementById('auto-remove');
+const debugLoggingCheckbox = document.getElementById('debug-logging');
+const lastUpdatedEl = document.getElementById('last-updated');
+
+const sendMessage = (message) => browserApi.runtime.sendMessage(message);
+
+const formatTimestamp = (timestamp) => {
+  return new Date(timestamp).toLocaleTimeString();
+};
+
+const renderPlaybackStatus = () => {
+  playbackStatus.textContent = appState.playbackState.replace(/^./, (char) => char.toUpperCase());
+};
+
+const setSelectedEpisode = (episodeId) => {
+  selectedEpisodeId = episodeId;
+  Array.from(queueList.children).forEach((child) => {
+    child.classList.toggle('selected', child.dataset.id === selectedEpisodeId);
+  });
+  if (!episodeId) {
+    audioLanguageSelect.value = appState.settings.defaultAudioLanguage;
+    return;
+  }
+  const episode = appState.queue.find((item) => item.id === episodeId);
+  if (episode) {
+    audioLanguageSelect.value = episode.audioLanguage || appState.settings.defaultAudioLanguage;
+  }
+};
+
+const renderQueue = () => {
+  queueList.innerHTML = '';
+  appState.queue.forEach((episode) => {
+    const item = document.createElement('li');
+    item.className = 'queue-item';
+    item.draggable = true;
+    item.dataset.id = episode.id;
+
+    const thumb = document.createElement('img');
+    thumb.src = episode.thumbnail || browserApi.runtime.getURL('assets/icon-48.svg');
+    thumb.alt = '';
+
+    const metadata = document.createElement('div');
+    metadata.className = 'metadata';
+
+    const title = document.createElement('span');
+    title.className = 'title';
+    title.textContent = episode.title || 'Untitled episode';
+
+    const subtitle = document.createElement('span');
+    subtitle.className = 'subtitle';
+    subtitle.textContent = episode.subtitle || '';
+
+    const language = document.createElement('span');
+    language.className = 'language';
+    language.textContent = episode.audioLanguage || appState.settings.defaultAudioLanguage;
+
+    metadata.append(title, subtitle, language);
+
+    const openButton = document.createElement('button');
+    openButton.type = 'button';
+    openButton.textContent = 'Open';
+    openButton.addEventListener('click', (event) => {
+      event.stopPropagation();
+      if (episode.url) {
+        browserApi.tabs.create({ url: episode.url });
+      }
+    });
+
+    item.append(thumb, metadata, openButton);
+
+    item.addEventListener('click', () => setSelectedEpisode(episode.id));
+    item.addEventListener('dragstart', (event) => {
+      item.classList.add('dragging');
+      event.dataTransfer.effectAllowed = 'move';
+      event.dataTransfer.setData('text/plain', episode.id);
+    });
+    item.addEventListener('dragend', () => {
+      item.classList.remove('dragging');
+    });
+
+    queueList.appendChild(item);
+  });
+  setSelectedEpisode(selectedEpisodeId);
+};
+
+const ensureLanguageOptions = () => {
+  if (audioLanguageSelect.childElementCount) {
+    return;
+  }
+  AUDIO_LANGUAGES.forEach((language) => {
+    const option = document.createElement('option');
+    option.value = language.code;
+    option.textContent = `${language.label} (${language.code})`;
+    audioLanguageSelect.appendChild(option);
+  });
+};
+
+const handleDragOver = (event) => {
+  event.preventDefault();
+  const dragging = queueList.querySelector('.dragging');
+  if (!dragging) {
+    return;
+  }
+  const afterElement = Array.from(queueList.children)
+    .filter((child) => child !== dragging)
+    .reduce((closest, child) => {
+      const box = child.getBoundingClientRect();
+      const offset = event.clientY - box.top - box.height / 2;
+      if (offset < 0 && offset > closest.offset) {
+        return { offset, element: child };
+      }
+      return closest;
+    }, { offset: Number.NEGATIVE_INFINITY, element: null }).element;
+  if (afterElement == null) {
+    queueList.appendChild(dragging);
+  } else {
+    queueList.insertBefore(dragging, afterElement);
+  }
+};
+
+const handleDrop = (event) => {
+  event.preventDefault();
+  const orderedIds = Array.from(queueList.children).map((child) => child.dataset.id);
+  sendMessage({
+    type: MESSAGE_TYPES.REORDER_QUEUE,
+    payload: { ids: orderedIds }
+  });
+};
+
+queueList.addEventListener('dragover', handleDragOver);
+queueList.addEventListener('drop', handleDrop);
+
+const bindControls = () => {
+  document.getElementById('play-button').addEventListener('click', async () => {
+    if (!selectedEpisodeId) {
+      return;
+    }
+    const episode = appState.queue.find((item) => item.id === selectedEpisodeId);
+    if (episode?.url) {
+      await browserApi.tabs.create({ url: episode.url });
+      sendMessage({
+        type: MESSAGE_TYPES.SELECT_EPISODE,
+        payload: { id: selectedEpisodeId }
+      });
+    }
+  });
+
+  document.getElementById('pause-button').addEventListener('click', () => {
+    sendMessage({
+      type: MESSAGE_TYPES.UPDATE_PLAYBACK_STATE,
+      payload: { state: PLAYBACK_STATES.PAUSED }
+    });
+  });
+
+  document.getElementById('remove-button').addEventListener('click', () => {
+    if (!selectedEpisodeId) {
+      return;
+    }
+    sendMessage({
+      type: MESSAGE_TYPES.REMOVE_EPISODE,
+      payload: { id: selectedEpisodeId }
+    });
+    setSelectedEpisode(null);
+  });
+
+  audioLanguageSelect.addEventListener('change', () => {
+    const value = audioLanguageSelect.value;
+    if (selectedEpisodeId) {
+      sendMessage({
+        type: MESSAGE_TYPES.SET_AUDIO_LANGUAGE,
+        payload: { id: selectedEpisodeId, audioLanguage: value }
+      });
+    } else {
+      sendMessage({
+        type: MESSAGE_TYPES.UPDATE_SETTINGS,
+        payload: { settings: { defaultAudioLanguage: value } }
+      });
+    }
+  });
+
+  autoRemoveCheckbox.addEventListener('change', () => {
+    sendMessage({
+      type: MESSAGE_TYPES.UPDATE_SETTINGS,
+      payload: { settings: { autoRemoveCompleted: autoRemoveCheckbox.checked } }
+    });
+  });
+
+  debugLoggingCheckbox.addEventListener('change', () => {
+    sendMessage({
+      type: MESSAGE_TYPES.UPDATE_SETTINGS,
+      payload: { settings: { debugLogging: debugLoggingCheckbox.checked } }
+    });
+  });
+
+  document.getElementById('debug-dump').addEventListener('click', async () => {
+    try {
+      const dump = await sendMessage({ type: MESSAGE_TYPES.REQUEST_DEBUG_DUMP });
+      if (dump) {
+        await navigator.clipboard.writeText(JSON.stringify(dump, null, 2));
+        const previous = lastUpdatedEl.textContent;
+        lastUpdatedEl.textContent = 'Debug info copied';
+        setTimeout(() => {
+          lastUpdatedEl.textContent = previous;
+        }, 2000);
+      }
+    } catch (error) {
+      console.error('Failed to copy debug info', error);
+    }
+  });
+};
+
+const applySettings = () => {
+  autoRemoveCheckbox.checked = appState.settings.autoRemoveCompleted;
+  debugLoggingCheckbox.checked = appState.settings.debugLogging;
+  if (!selectedEpisodeId) {
+    audioLanguageSelect.value = appState.settings.defaultAudioLanguage;
+  }
+};
+
+const updateState = (newState) => {
+  appState = newState;
+  renderPlaybackStatus();
+  renderQueue();
+  applySettings();
+  lastUpdatedEl.textContent = `Updated ${formatTimestamp(appState.lastUpdated)}`;
+  if (!selectedEpisodeId && appState.currentEpisodeId) {
+    setSelectedEpisode(appState.currentEpisodeId);
+  }
+};
+
+const init = async () => {
+  ensureLanguageOptions();
+  bindControls();
+  const currentState = await sendMessage({ type: MESSAGE_TYPES.GET_STATE });
+  if (currentState) {
+    updateState(currentState);
+  }
+};
+
+browserApi.runtime.onMessage.addListener((message) => {
+  if (message.type === MESSAGE_TYPES.STATE_UPDATED) {
+    updateState(message.payload);
+  }
+});
+
+init();


### PR DESCRIPTION
## Summary
- replace the action and extension icons with vector-based SVG assets
- update popup fallback references to match the new SVG icon filenames

## Testing
- not run (asset-only changes)


------
https://chatgpt.com/codex/tasks/task_e_68e3093c634083238b216159c46fc095