### PR TITLE
Expose background helpers and expand background test coverage

### DIFF
--- a/src/background.js
+++ b/src/background.js
@@ -16,13 +16,13 @@ let state = {
   lastUpdated: Date.now()
 };
 
-const persistState = async () => {
+export const persistState = async () => {
   await browserApi.storage.local.set({
     [STORAGE_KEYS.STATE]: state
   });
 };
 
-const loadState = async () => {
+export const loadState = async () => {
   const stored = await browserApi.storage.local.get(STORAGE_KEYS.STATE);
   if (stored && stored[STORAGE_KEYS.STATE]) {
     const storedState = stored[STORAGE_KEYS.STATE];
@@ -44,7 +44,7 @@ const debugLog = (...args) => {
   }
 };
 
-const broadcastState = async () => {
+export const broadcastState = async () => {
   state.lastUpdated = Date.now();
   await persistState();
   debugLog('Broadcasting state', state);
@@ -63,7 +63,7 @@ const ensureAudioLanguage = (episode) => ({
   audioLanguage: episode.audioLanguage || state.settings.defaultAudioLanguage
 });
 
-const addEpisodes = async (episodes) => {
+export const addEpisodes = async (episodes) => {
   let added = false;
   episodes.forEach((rawEpisode) => {
     const episode = ensureAudioLanguage(rawEpisode);
@@ -78,7 +78,7 @@ const addEpisodes = async (episodes) => {
   return added;
 };
 
-const removeEpisode = async (episodeId) => {
+export const removeEpisode = async (episodeId) => {
   const index = findEpisodeIndex(episodeId);
   if (index !== -1) {
     const [removed] = state.queue.splice(index, 1);
@@ -91,7 +91,7 @@ const removeEpisode = async (episodeId) => {
   }
 };
 
-const reorderQueue = async (orderedIds) => {
+export const reorderQueue = async (orderedIds) => {
   const newQueue = [];
   orderedIds.forEach((id) => {
     const item = state.queue.find((episode) => episode.id === id);
@@ -109,7 +109,7 @@ const reorderQueue = async (orderedIds) => {
   await broadcastState();
 };
 
-const setCurrentEpisode = async (episodeId) => {
+export const setCurrentEpisode = async (episodeId) => {
   if (episodeId && findEpisodeIndex(episodeId) === -1) {
     debugLog('Attempted to select unknown episode', episodeId);
     return;
@@ -118,7 +118,7 @@ const setCurrentEpisode = async (episodeId) => {
   await broadcastState();
 };
 
-const setPlaybackState = async (playbackState) => {
+export const setPlaybackState = async (playbackState) => {
   state.playbackState = playbackState;
   if (
     playbackState === PLAYBACK_STATES.ENDED &&
@@ -131,7 +131,7 @@ const setPlaybackState = async (playbackState) => {
   }
 };
 
-const controlPlayback = async (action) => {
+export const controlPlayback = async (action) => {
   if (!browserApi?.tabs?.query || !browserApi?.tabs?.sendMessage) {
     debugLog('Tabs API unavailable for playback control');
     return { success: false };
@@ -163,7 +163,7 @@ const controlPlayback = async (action) => {
   }
 };
 
-const updateSettings = async (settingsUpdate) => {
+export const updateSettings = async (settingsUpdate) => {
   state.settings = {
     ...state.settings,
     ...settingsUpdate
@@ -177,7 +177,7 @@ const updateSettings = async (settingsUpdate) => {
   await broadcastState();
 };
 
-const setAudioLanguage = async (episodeId, audioLanguage) => {
+export const setAudioLanguage = async (episodeId, audioLanguage) => {
   const index = findEpisodeIndex(episodeId);
   if (index !== -1) {
     const selectedLanguage = AUDIO_LANGUAGES.find((language) => language.code === audioLanguage);
@@ -220,12 +220,12 @@ const setAudioLanguage = async (episodeId, audioLanguage) => {
   }
 };
 
-const setQueue = async (episodes) => {
+export const setQueue = async (episodes) => {
   state.queue = episodes.map((episode) => ensureAudioLanguage(episode));
   await broadcastState();
 };
 
-const handleMessage = async (message) => {
+export const handleMessage = async (message) => {
   switch (message.type) {
     case MESSAGE_TYPES.GET_STATE:
       return state;

--- a/tests/background/playback.test.js
+++ b/tests/background/playback.test.js
@@ -1,0 +1,95 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import {
+  AUDIO_LANGUAGES,
+  DEFAULT_SETTINGS,
+  MESSAGE_TYPES,
+  PLAYBACK_STATES
+} from "../../src/constants.js";
+
+const getState = async (background) => background.handleMessage({ type: MESSAGE_TYPES.GET_STATE });
+
+describe("background playback controls", () => {
+  let background;
+
+  beforeEach(async () => {
+    background = await import("../../src/background.js");
+    await background.setQueue([]);
+    await background.setCurrentEpisode(null);
+    await background.setPlaybackState(PLAYBACK_STATES.IDLE);
+    await background.updateSettings({ ...DEFAULT_SETTINGS });
+    globalThis.browser.tabs.query.mockClear();
+    globalThis.browser.tabs.sendMessage.mockClear();
+  });
+
+  it("removes the current episode when playback ends and auto-remove is enabled", async () => {
+    await background.setQueue([
+      { id: "ep-1", title: "Episode 1" },
+      { id: "ep-2", title: "Episode 2" }
+    ]);
+    await background.setCurrentEpisode("ep-1");
+
+    await background.setPlaybackState(PLAYBACK_STATES.ENDED);
+
+    const state = await getState(background);
+    expect(state.queue.map((episode) => episode.id)).toEqual(["ep-2"]);
+    expect(state.currentEpisodeId).toBeNull();
+    expect(state.playbackState).toBe(PLAYBACK_STATES.IDLE);
+  });
+
+  it("returns a failure result when no Crunchyroll tab can be controlled", async () => {
+    const result = await background.controlPlayback("play");
+
+    expect(result).toEqual({ success: false });
+    expect(globalThis.browser.tabs.query).toHaveBeenCalledTimes(1);
+    expect(globalThis.browser.tabs.sendMessage).not.toHaveBeenCalled();
+  });
+
+  it("delegates playback control to the active Crunchyroll tab when available", async () => {
+    const browser = globalThis.browser;
+    browser.tabs.__setQueryHandler(async () => [
+      { id: 42, active: true, url: "https://www.crunchyroll.com/watch/episode" }
+    ]);
+    browser.tabs.__setSendMessageHandler(async () => ({ success: true }));
+
+    const response = await background.controlPlayback("pause");
+
+    expect(response).toEqual({ success: true });
+    expect(browser.tabs.query).toHaveBeenCalledTimes(1);
+    expect(browser.tabs.sendMessage).toHaveBeenCalledTimes(1);
+    const [tabId, message] = browser.tabs.sendMessage.mock.calls[0];
+    expect(tabId).toBe(42);
+    expect(message).toEqual({
+      type: MESSAGE_TYPES.CONTROL_PLAYBACK,
+      payload: { action: "pause" }
+    });
+  });
+
+  it("broadcasts audio language updates to all active Crunchyroll tabs", async () => {
+    await background.setQueue([
+      { id: "episode-a", title: "Episode A" }
+    ]);
+
+    const browser = globalThis.browser;
+    browser.tabs.__setQueryHandler(async () => [
+      { id: 1, active: true, url: "https://www.crunchyroll.com/series" },
+      { id: 2, active: true, url: "https://www.crunchyroll.com/watch" }
+    ]);
+    browser.tabs.sendMessage.mockClear();
+
+    await background.setAudioLanguage("episode-a", AUDIO_LANGUAGES[1].code);
+
+    const state = await getState(background);
+    expect(state.queue[0].audioLanguage).toBe(AUDIO_LANGUAGES[1].code);
+    expect(browser.tabs.sendMessage).toHaveBeenCalledTimes(2);
+    const payloads = browser.tabs.sendMessage.mock.calls.map(([, payload]) => payload);
+    payloads.forEach((payload) => {
+      expect(payload).toEqual({
+        type: MESSAGE_TYPES.APPLY_AUDIO_LANGUAGE,
+        payload: {
+          audioLanguage: AUDIO_LANGUAGES[1].code,
+          label: AUDIO_LANGUAGES[1].label
+        }
+      });
+    });
+  });
+});

--- a/tests/background/queue.test.js
+++ b/tests/background/queue.test.js
@@ -1,0 +1,68 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import { DEFAULT_SETTINGS, MESSAGE_TYPES, PLAYBACK_STATES } from "../../src/constants.js";
+
+const getState = async (background) => background.handleMessage({ type: MESSAGE_TYPES.GET_STATE });
+
+describe("background queue mutations", () => {
+  let background;
+
+  beforeEach(async () => {
+    background = await import("../../src/background.js");
+    await background.setQueue([]);
+    await background.setCurrentEpisode(null);
+    await background.setPlaybackState(PLAYBACK_STATES.IDLE);
+    await background.updateSettings({ ...DEFAULT_SETTINGS });
+  });
+
+  it("avoids adding duplicate episodes", async () => {
+    const episode = { id: "episode-1", title: "Episode 1" };
+    await background.addEpisodes([episode]);
+    await background.addEpisodes([episode]);
+
+    const state = await getState(background);
+    expect(state.queue).toHaveLength(1);
+    expect(state.queue[0].id).toBe("episode-1");
+  });
+
+  it("preserves order by appending unspecified episodes when reordering", async () => {
+    await background.setQueue([
+      { id: "episode-a", title: "Episode A" },
+      { id: "episode-b", title: "Episode B" },
+      { id: "episode-c", title: "Episode C" }
+    ]);
+
+    await background.reorderQueue(["episode-c", "episode-a"]);
+
+    const state = await getState(background);
+    expect(state.queue.map((episode) => episode.id)).toEqual([
+      "episode-c",
+      "episode-a",
+      "episode-b"
+    ]);
+  });
+
+  it("adds only new episodes when handling ADD_EPISODE_AND_NEWER", async () => {
+    await background.setQueue([
+      { id: "older", title: "Older Episode" },
+      { id: "current", title: "Current Episode" }
+    ]);
+    await background.setCurrentEpisode("current");
+
+    const resultState = await background.handleMessage({
+      type: MESSAGE_TYPES.ADD_EPISODE_AND_NEWER,
+      payload: [
+        { id: "current", title: "Current Episode" },
+        { id: "next-1", title: "Next Episode 1" },
+        { id: "next-2", title: "Next Episode 2" }
+      ]
+    });
+
+    expect(resultState.queue.map((episode) => episode.id)).toEqual([
+      "older",
+      "current",
+      "next-1",
+      "next-2"
+    ]);
+    expect(new Set(resultState.queue.map((episode) => episode.id)).size).toBe(4);
+  });
+});

--- a/tests/background/settings.test.js
+++ b/tests/background/settings.test.js
@@ -1,0 +1,162 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  AUDIO_LANGUAGES,
+  DEFAULT_SETTINGS,
+  MESSAGE_TYPES,
+  PLAYBACK_STATES,
+  STORAGE_KEYS
+} from "../../src/constants.js";
+
+const getState = async (background) => background.handleMessage({ type: MESSAGE_TYPES.GET_STATE });
+
+describe("background settings and persistence", () => {
+  let background;
+
+  beforeEach(async () => {
+    background = await import("../../src/background.js");
+    await background.setQueue([]);
+    await background.setCurrentEpisode(null);
+    await background.setPlaybackState(PLAYBACK_STATES.IDLE);
+    await background.updateSettings({ ...DEFAULT_SETTINGS });
+    globalThis.browser.storage.local.get.mockClear();
+    globalThis.browser.storage.local.set.mockClear();
+    globalThis.browser.runtime.sendMessage.mockClear();
+  });
+
+  it("merges updated settings and applies the default audio language to existing episodes", async () => {
+    const state = await getState(background);
+    state.queue = [
+      { id: "existing", title: "Existing Episode", audioLanguage: null },
+      { id: "another", title: "Another Episode", audioLanguage: undefined }
+    ];
+
+    await background.updateSettings({
+      defaultAudioLanguage: AUDIO_LANGUAGES[1].code,
+      autoRemoveCompleted: false
+    });
+
+    expect(state.settings.defaultAudioLanguage).toBe(AUDIO_LANGUAGES[1].code);
+    expect(state.settings.autoRemoveCompleted).toBe(false);
+    expect(state.queue.every((episode) => episode.audioLanguage === AUDIO_LANGUAGES[1].code)).toBe(true);
+  });
+
+  it("persists the current state into extension storage", async () => {
+    const state = await getState(background);
+    state.queue = [{ id: "persist", title: "Persisted" }];
+    state.currentEpisodeId = "persist";
+    state.playbackState = PLAYBACK_STATES.PLAYING;
+
+    await background.persistState();
+
+    expect(globalThis.browser.storage.local.set).toHaveBeenCalledWith({
+      [STORAGE_KEYS.STATE]: state
+    });
+  });
+
+  it("loads stored state and merges defaults", async () => {
+    const storedState = {
+      queue: [{ id: "stored", title: "Stored Episode", audioLanguage: "es-ES" }],
+      currentEpisodeId: "stored",
+      playbackState: PLAYBACK_STATES.PAUSED,
+      settings: {
+        defaultAudioLanguage: "es-ES",
+        debugLogging: true
+      },
+      lastUpdated: 12345
+    };
+    globalThis.browser.__storageStore.set(STORAGE_KEYS.STATE, storedState);
+
+    await background.loadState();
+
+    const state = await getState(background);
+    expect(state.queue.map((episode) => episode.id)).toEqual(["stored"]);
+    expect(state.currentEpisodeId).toBe("stored");
+    expect(state.playbackState).toBe(PLAYBACK_STATES.PAUSED);
+    expect(state.settings).toEqual({
+      ...DEFAULT_SETTINGS,
+      ...storedState.settings
+    });
+    expect(state.lastUpdated).toBe(12345);
+  });
+
+  it("updates timestamps, persists state, and notifies listeners when broadcasting", async () => {
+    const originalState = await getState(background);
+    const initialTimestamp = originalState.lastUpdated;
+    vi.setSystemTime(new Date("2024-01-01T00:00:00Z"));
+
+    await background.broadcastState();
+
+    const state = await getState(background);
+    expect(state.lastUpdated).toBe(new Date("2024-01-01T00:00:00Z").getTime());
+    expect(globalThis.browser.storage.local.set).toHaveBeenCalled();
+    expect(globalThis.browser.runtime.sendMessage).toHaveBeenCalledWith({
+      type: MESSAGE_TYPES.STATE_UPDATED,
+      payload: state
+    });
+    expect(state.lastUpdated).not.toBe(initialTimestamp);
+  });
+
+  it("dispatches all supported messages and logs unknown requests", async () => {
+    const consoleSpy = vi.spyOn(console, "debug").mockImplementation(() => {});
+
+    await background.handleMessage({
+      type: MESSAGE_TYPES.ADD_EPISODE,
+      payload: { id: "msg-1", title: "Message Episode" }
+    });
+    await background.handleMessage({
+      type: MESSAGE_TYPES.ADD_EPISODE_AND_NEWER,
+      payload: [
+        { id: "msg-1", title: "Message Episode" },
+        { id: "msg-2", title: "Second" }
+      ]
+    });
+    await background.handleMessage({
+      type: MESSAGE_TYPES.REMOVE_EPISODE,
+      payload: { id: "msg-1" }
+    });
+    await background.handleMessage({
+      type: MESSAGE_TYPES.REORDER_QUEUE,
+      payload: { ids: ["msg-2"] }
+    });
+    await background.handleMessage({
+      type: MESSAGE_TYPES.SELECT_EPISODE,
+      payload: { id: "msg-2" }
+    });
+    await background.handleMessage({
+      type: MESSAGE_TYPES.UPDATE_PLAYBACK_STATE,
+      payload: { state: PLAYBACK_STATES.PLAYING }
+    });
+    await background.handleMessage({
+      type: MESSAGE_TYPES.CONTROL_PLAYBACK,
+      payload: { action: "play" }
+    });
+    await background.handleMessage({
+      type: MESSAGE_TYPES.UPDATE_SETTINGS,
+      payload: { settings: { debugLogging: true } }
+    });
+    await background.handleMessage({
+      type: MESSAGE_TYPES.SET_AUDIO_LANGUAGE,
+      payload: { id: "msg-2", audioLanguage: AUDIO_LANGUAGES[0].code }
+    });
+    await background.handleMessage({
+      type: MESSAGE_TYPES.SET_QUEUE,
+      payload: { queue: [{ id: "msg-3", title: "Another" }] }
+    });
+    const debugDump = await background.handleMessage({
+      type: MESSAGE_TYPES.REQUEST_DEBUG_DUMP
+    });
+    expect(debugDump).toMatchObject({
+      timestamp: expect.any(String),
+      audioLanguages: AUDIO_LANGUAGES
+    });
+
+    await background.handleMessage({ type: "UNKNOWN_TYPE" });
+
+    expect(consoleSpy).toHaveBeenCalledWith(
+      "[RollQueue]",
+      "Unknown message",
+      { type: "UNKNOWN_TYPE" }
+    );
+    consoleSpy.mockRestore();
+  });
+});

--- a/tests/setup.js
+++ b/tests/setup.js
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, vi } from "vitest";
-import { cleanup } from "@testing-library/dom";
+import { cleanup as cleanupDom } from "@testing-library/dom";
 import { installMockBrowserApi, resetBrowserApi } from "./support/mockBrowserApi.js";
 import { useMockedTimers, restoreRealTimers } from "./support/timers.js";
 
@@ -9,7 +9,9 @@ beforeEach(() => {
 });
 
 afterEach(() => {
-  cleanup();
+  if (typeof cleanupDom === "function") {
+    cleanupDom();
+  }
   restoreRealTimers();
   resetBrowserApi();
   vi.clearAllMocks();

--- a/tests/support/mockBrowserApi.js
+++ b/tests/support/mockBrowserApi.js
@@ -1,5 +1,76 @@
 import { vi } from "vitest";
 
+function createDeferred() {
+  let resolve;
+  let reject;
+  const promise = new Promise((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+}
+
+function createTrackedAsyncFunction(handler = async () => undefined, { autoResolve = true } = {}) {
+  let currentHandler = handler;
+  let shouldAutoResolve = autoResolve;
+  const calls = [];
+
+  const fn = vi.fn((...args) => {
+    const deferred = createDeferred();
+    const callRecord = {
+      args,
+      resolve: deferred.resolve,
+      reject: deferred.reject,
+      promise: deferred.promise,
+      settled: false
+    };
+    calls.push(callRecord);
+
+    if (shouldAutoResolve && typeof currentHandler === "function") {
+      Promise.resolve()
+        .then(() => currentHandler(...args))
+        .then((value) => {
+          if (!callRecord.settled) {
+            callRecord.settled = true;
+            deferred.resolve(value);
+          }
+        })
+        .catch((error) => {
+          if (!callRecord.settled) {
+            callRecord.settled = true;
+            deferred.reject(error);
+          }
+        });
+    }
+
+    return deferred.promise;
+  });
+
+  fn.__calls = calls;
+  fn.__resolve = (value, index = calls.length - 1) => {
+    const call = calls[index];
+    if (call && !call.settled) {
+      call.settled = true;
+      call.resolve(value);
+    }
+  };
+  fn.__reject = (error, index = calls.length - 1) => {
+    const call = calls[index];
+    if (call && !call.settled) {
+      call.settled = true;
+      call.reject(error);
+    }
+  };
+  fn.__setHandler = (newHandler) => {
+    currentHandler = newHandler;
+  };
+  fn.__setAutoResolve = (value) => {
+    shouldAutoResolve = value;
+  };
+
+  return fn;
+}
+
 function toArray(value) {
   if (Array.isArray(value)) {
     return value;
@@ -26,10 +97,11 @@ function mergeDeep(target, source = {}) {
 
 export function createMockBrowser(overrides = {}) {
   const messageListeners = new Set();
+  const installedListeners = new Set();
   const localStore = new Map();
 
   const runtime = {
-    sendMessage: vi.fn(async () => undefined),
+    sendMessage: createTrackedAsyncFunction(async () => undefined),
     onMessage: {
       addListener: vi.fn((callback) => {
         messageListeners.add(callback);
@@ -38,12 +110,28 @@ export function createMockBrowser(overrides = {}) {
         messageListeners.delete(callback);
       }),
       hasListener: vi.fn((callback) => messageListeners.has(callback))
+    },
+    onInstalled: {
+      addListener: vi.fn((callback) => {
+        installedListeners.add(callback);
+      }),
+      removeListener: vi.fn((callback) => {
+        installedListeners.delete(callback);
+      }),
+      hasListener: vi.fn((callback) => installedListeners.has(callback))
     }
   };
+  runtime.__calls = {
+    sendMessage: runtime.sendMessage.__calls
+  };
+  runtime.__resolveSendMessage = runtime.sendMessage.__resolve;
+  runtime.__rejectSendMessage = runtime.sendMessage.__reject;
+  runtime.__setSendMessageHandler = runtime.sendMessage.__setHandler;
+  runtime.__setSendMessageAutoResolve = runtime.sendMessage.__setAutoResolve;
 
   const storage = {
     local: {
-      get: vi.fn(async (keys) => {
+      get: createTrackedAsyncFunction(async (keys) => {
         const requestedKeys = Array.isArray(keys)
           ? keys
           : keys && typeof keys === "object" && !Array.isArray(keys)
@@ -64,27 +152,61 @@ export function createMockBrowser(overrides = {}) {
           return accumulator;
         }, {});
       }),
-      set: vi.fn(async (items = {}) => {
+      set: createTrackedAsyncFunction(async (items = {}) => {
         Object.entries(items).forEach(([key, value]) => {
           localStore.set(key, value);
         });
       }),
-      remove: vi.fn(async (keys) => {
+      remove: createTrackedAsyncFunction(async (keys) => {
         toArray(keys).forEach((key) => {
           localStore.delete(key);
         });
       }),
-      clear: vi.fn(async () => {
+      clear: createTrackedAsyncFunction(async () => {
         localStore.clear();
       })
     }
   };
+  storage.local.__calls = {
+    get: storage.local.get.__calls,
+    set: storage.local.set.__calls,
+    remove: storage.local.remove.__calls,
+    clear: storage.local.clear.__calls
+  };
+  storage.local.__resolveGet = storage.local.get.__resolve;
+  storage.local.__rejectGet = storage.local.get.__reject;
+  storage.local.__resolveSet = storage.local.set.__resolve;
+  storage.local.__rejectSet = storage.local.set.__reject;
+  storage.local.__resolveRemove = storage.local.remove.__resolve;
+  storage.local.__rejectRemove = storage.local.remove.__reject;
+  storage.local.__resolveClear = storage.local.clear.__resolve;
+  storage.local.__rejectClear = storage.local.clear.__reject;
+  storage.local.__setGetHandler = storage.local.get.__setHandler;
+  storage.local.__setSetHandler = storage.local.set.__setHandler;
+  storage.local.__setRemoveHandler = storage.local.remove.__setHandler;
+  storage.local.__setClearHandler = storage.local.clear.__setHandler;
+  storage.local.__setGetAutoResolve = storage.local.get.__setAutoResolve;
+  storage.local.__setSetAutoResolve = storage.local.set.__setAutoResolve;
+  storage.local.__setRemoveAutoResolve = storage.local.remove.__setAutoResolve;
+  storage.local.__setClearAutoResolve = storage.local.clear.__setAutoResolve;
 
   const tabs = {
-    query: vi.fn(async () => []),
-    sendMessage: vi.fn(async () => undefined),
+    query: createTrackedAsyncFunction(async () => []),
+    sendMessage: createTrackedAsyncFunction(async () => undefined),
     create: vi.fn(async (tab) => ({ id: Math.floor(Math.random() * 1000), ...tab }))
   };
+  tabs.__calls = {
+    query: tabs.query.__calls,
+    sendMessage: tabs.sendMessage.__calls
+  };
+  tabs.__resolveQuery = tabs.query.__resolve;
+  tabs.__rejectQuery = tabs.query.__reject;
+  tabs.__resolveSendMessage = tabs.sendMessage.__resolve;
+  tabs.__rejectSendMessage = tabs.sendMessage.__reject;
+  tabs.__setQueryHandler = tabs.query.__setHandler;
+  tabs.__setSendMessageHandler = tabs.sendMessage.__setHandler;
+  tabs.__setQueryAutoResolve = tabs.query.__setAutoResolve;
+  tabs.__setSendMessageAutoResolve = tabs.sendMessage.__setAutoResolve;
 
   const baseBrowser = {
     runtime,
@@ -93,12 +215,16 @@ export function createMockBrowser(overrides = {}) {
     __emitMessage(payload, sender = {}, sendResponse = () => {}) {
       messageListeners.forEach((listener) => listener(payload, sender, sendResponse));
     },
+    __emitInstalled(details) {
+      installedListeners.forEach((listener) => listener(details));
+    },
     __storageStore: localStore
   };
 
   const browser = mergeDeep(baseBrowser, overrides);
 
   browser.runtime.onMessage.emit = browser.__emitMessage;
+  browser.runtime.onInstalled.emit = browser.__emitInstalled;
 
   return browser;
 }


### PR DESCRIPTION
## Summary
- export the background helpers so they can be directly exercised without breaking extension listeners
- enhance the browser API mock with tracked async utilities for runtime messages, storage, and tab messaging
- add queue, playback, and settings test suites covering background behaviors and persistence helpers

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e322085a2c8323bbbf30313fd15122