### PR TITLE
Refactor content script helpers and add tests

### DIFF
--- a/tests/content/audio-language.test.js
+++ b/tests/content/audio-language.test.js
@@ -1,0 +1,106 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import * as content from "../../src/content.js";
+import { renderAudioMenu, clearDom } from "./dom.fixtures.js";
+
+const {
+  buildLanguageCandidates,
+  setVideoAudioTrack,
+  applyAudioLanguageDirective,
+  contentMessageListener,
+  MESSAGE_TYPES,
+  PLAYBACK_STATES,
+  __testInternals
+} = content;
+
+describe("content audio language helpers", () => {
+  beforeEach(() => {
+    clearDom();
+    __testInternals.trackedVideo = null;
+    globalThis.browser.runtime.sendMessage.mockClear();
+  });
+
+  it("builds normalized language candidates", () => {
+    const candidates = buildLanguageCandidates("en-US", "English (US)");
+    expect(candidates).toEqual(
+      expect.arrayContaining(["en-us", "en", "english", "english (us)"])
+    );
+  });
+
+  it("enables audio tracks directly when available", () => {
+    const audioTracks = [
+      { language: "ja-JP", label: "Japanese", enabled: true },
+      { language: "en-US", label: "English", enabled: false }
+    ];
+    const video = { audioTracks };
+
+    const switched = setVideoAudioTrack(video, "en-US", "English");
+
+    expect(switched).toBe(true);
+    expect(audioTracks[0].enabled).toBe(false);
+    expect(audioTracks[1].enabled).toBe(true);
+  });
+
+  it("falls back to selecting audio tracks from the menu", async () => {
+    const video = document.createElement("video");
+    document.body.append(video);
+    Object.defineProperty(video, "audioTracks", {
+      configurable: true,
+      get() {
+        return undefined;
+      }
+    });
+
+    const { toggle } = renderAudioMenu();
+
+    const switched = await applyAudioLanguageDirective({ audioLanguage: "en-US" });
+
+    expect(switched).toBe(true);
+    expect(toggle.getAttribute("aria-expanded")).toBe("false");
+
+    const lastMessage = globalThis.browser.runtime.sendMessage.mock.calls.at(-1);
+    expect(lastMessage[0]).toMatchObject({
+      type: MESSAGE_TYPES.UPDATE_PLAYBACK_STATE,
+      payload: { state: PLAYBACK_STATES.PAUSED }
+    });
+  });
+
+  it("responds to APPLY_AUDIO_LANGUAGE messages with success and failure", async () => {
+    const video = document.createElement("video");
+    document.body.append(video);
+    Object.defineProperty(video, "audioTracks", {
+      configurable: true,
+      get() {
+        return undefined;
+      }
+    });
+    renderAudioMenu();
+
+    const sendResponseSuccess = vi.fn();
+    const result = contentMessageListener(
+      { type: MESSAGE_TYPES.APPLY_AUDIO_LANGUAGE, payload: { audioLanguage: "en-US" } },
+      {},
+      sendResponseSuccess
+    );
+
+    expect(result).toBe(true);
+    await Promise.resolve();
+    await vi.runAllTimersAsync();
+    await Promise.resolve();
+    expect(sendResponseSuccess).toHaveBeenCalledWith({ success: true });
+
+    clearDom();
+    const sendResponseFailure = vi.fn();
+    const failureResult = contentMessageListener(
+      { type: MESSAGE_TYPES.APPLY_AUDIO_LANGUAGE, payload: { audioLanguage: "de-DE" } },
+      {},
+      sendResponseFailure
+    );
+
+    expect(failureResult).toBe(true);
+    await Promise.resolve();
+    await vi.runAllTimersAsync();
+    await Promise.resolve();
+    expect(sendResponseFailure).toHaveBeenCalledWith({ success: false });
+  });
+});
+

--- a/tests/content/dom.fixtures.js
+++ b/tests/content/dom.fixtures.js
@@ -1,0 +1,132 @@
+const DEFAULT_EPISODES = [
+  {
+    id: "episode-1",
+    url: "https://www.crunchyroll.com/watch/episode-1",
+    title: "Episode 1",
+    subtitle: "Season 1 · Episode 1",
+    thumbnail: "https://cdn.crunchyroll.com/thumb-1.jpg"
+  },
+  {
+    id: "episode-2",
+    url: "https://www.crunchyroll.com/watch/episode-2",
+    title: "Episode 2",
+    subtitle: "Season 1 · Episode 2",
+    thumbnail: "https://cdn.crunchyroll.com/thumb-2.jpg"
+  },
+  {
+    id: "episode-3",
+    url: "https://www.crunchyroll.com/watch/episode-3",
+    title: "Episode 3",
+    subtitle: "Season 1 · Episode 3",
+    thumbnail: "https://cdn.crunchyroll.com/thumb-3.jpg"
+  }
+];
+
+function createEpisodeCard({ id, url, title, subtitle, thumbnail }) {
+  const card = document.createElement("li");
+  card.dataset.testid = "episode-card";
+
+  const anchor = document.createElement("a");
+  anchor.href = url;
+  anchor.dataset.testid = "episode-link";
+
+  const thumbnailImg = document.createElement("img");
+  thumbnailImg.src = thumbnail;
+  thumbnailImg.alt = `${title} thumbnail`;
+
+  const titleEl = document.createElement("h3");
+  titleEl.dataset.testid = "media-card-title";
+  titleEl.textContent = title;
+
+  const subtitleEl = document.createElement("p");
+  subtitleEl.dataset.testid = "media-card-subtitle";
+  subtitleEl.textContent = subtitle;
+
+  anchor.append(thumbnailImg, titleEl, subtitleEl);
+  card.append(anchor);
+
+  const menu = document.createElement("ul");
+  menu.setAttribute("role", "menu");
+  const existingItem = document.createElement("li");
+  existingItem.textContent = "Existing option";
+  menu.append(existingItem);
+  card.append(menu);
+
+  return { card, menu };
+}
+
+export function renderEpisodeCards(episodes = DEFAULT_EPISODES) {
+  document.body.innerHTML = "";
+  const list = document.createElement("ul");
+  list.dataset.testid = "episode-list";
+  const menus = [];
+  const cards = episodes.map((episode) => {
+    const { card, menu } = createEpisodeCard(episode);
+    menus.push(menu);
+    list.append(card);
+    return card;
+  });
+
+  document.body.append(list);
+
+  return { container: list, cards, menus };
+}
+
+export function renderEpisodeMenu(card) {
+  const menu = document.createElement("ul");
+  menu.setAttribute("role", "menu");
+  const existingItem = document.createElement("li");
+  existingItem.textContent = "Existing option";
+  menu.append(existingItem);
+  card.append(menu);
+  return menu;
+}
+
+export function renderAudioMenu({
+  options = [
+    { label: "English", value: "en-US" },
+    { label: "Japanese", value: "ja-JP" }
+  ]
+} = {}) {
+  const container = document.createElement("div");
+  container.dataset.testid = "audio-menu-container";
+
+  const toggle = document.createElement("button");
+  toggle.type = "button";
+  toggle.dataset.testid = "audio-menu-button";
+  toggle.setAttribute("aria-label", "Audio");
+  toggle.setAttribute("aria-expanded", "false");
+
+  const menu = document.createElement("div");
+  menu.dataset.testid = "audio-menu";
+  menu.setAttribute("role", "menu");
+  menu.hidden = true;
+
+  toggle.addEventListener("click", () => {
+    const expanded = toggle.getAttribute("aria-expanded") === "true";
+    const next = !expanded;
+    toggle.setAttribute("aria-expanded", next ? "true" : "false");
+    menu.hidden = !next;
+  });
+
+  const optionElements = options.map(({ label, value }) => {
+    const option = document.createElement("button");
+    option.type = "button";
+    option.dataset.testid = "audio-menu-option";
+    option.dataset.value = value;
+    option.setAttribute("role", "menuitemradio");
+    option.textContent = label;
+    menu.append(option);
+    return option;
+  });
+
+  container.append(toggle, menu);
+  document.body.append(container);
+
+  return { container, toggle, menu, options: optionElements };
+}
+
+export function clearDom() {
+  document.body.innerHTML = "";
+}
+

--- a/tests/content/menu.test.js
+++ b/tests/content/menu.test.js
@@ -1,0 +1,83 @@
+import { describe, expect, it, beforeEach } from "vitest";
+import {
+  annotateEpisodeCards,
+  injectMenuItems,
+  gatherEpisodesFromCard,
+  MENU_ITEM_ATTRIBUTE,
+  MESSAGE_TYPES
+} from "../../src/content.js";
+import { renderEpisodeCards, clearDom } from "./dom.fixtures.js";
+
+describe("content menu helpers", () => {
+  beforeEach(() => {
+    clearDom();
+    globalThis.browser.runtime.sendMessage.mockClear();
+  });
+
+  it("annotates episode cards with metadata", () => {
+    const { cards } = renderEpisodeCards();
+
+    annotateEpisodeCards();
+
+    cards.forEach((card, index) => {
+      const expectedId = `episode-${index + 1}`;
+      expect(card.getAttribute("data-rollqueue-episode-id")).toBe(expectedId);
+      expect(card.getAttribute("data-rollqueue-episode-url")).toContain(expectedId);
+      expect(card.getAttribute("data-rollqueue-episode-title")).toBe(`Episode ${index + 1}`);
+      expect(card.getAttribute("data-rollqueue-episode-subtitle")).toContain(`Episode ${index + 1}`);
+      expect(card.getAttribute("data-rollqueue-episode-thumbnail")).toContain(`thumb-${index + 1}`);
+    });
+  });
+
+  it("injects menu items idempotently", () => {
+    const { menus } = renderEpisodeCards();
+
+    annotateEpisodeCards();
+
+    const menu = menus[0];
+
+    injectMenuItems(menu);
+    injectMenuItems(menu);
+
+    const injectedItems = menu.querySelectorAll(`[${MENU_ITEM_ATTRIBUTE}]`);
+    expect(injectedItems.length).toBe(2);
+  });
+
+  it("dispatches correct messages from injected menu actions", async () => {
+    const { cards, menus } = renderEpisodeCards();
+    annotateEpisodeCards();
+    const menu = menus[0];
+    const card = cards[0];
+
+    injectMenuItems(menu);
+
+    const items = menu.querySelectorAll(`[${MENU_ITEM_ATTRIBUTE}] button`);
+    expect(items.length).toBe(2);
+
+    items[0].click();
+    await Promise.resolve();
+
+    const firstCall = globalThis.browser.runtime.sendMessage.mock.calls[0][0];
+    expect(firstCall).toMatchObject({
+      type: MESSAGE_TYPES.ADD_EPISODE,
+      payload: expect.objectContaining({
+        id: card.getAttribute("data-rollqueue-episode-id")
+      })
+    });
+
+    items[1].click();
+    await Promise.resolve();
+
+    const secondCall = globalThis.browser.runtime.sendMessage.mock.calls[1][0];
+    expect(secondCall).toMatchObject({
+      type: MESSAGE_TYPES.ADD_EPISODE_AND_NEWER,
+      payload: expect.arrayContaining([
+        expect.objectContaining({ id: card.getAttribute("data-rollqueue-episode-id") })
+      ])
+    });
+
+    const gatheredEpisodes = gatherEpisodesFromCard(card, true);
+    expect(gatheredEpisodes.length).toBeGreaterThan(1);
+  });
+});
+

--- a/tests/content/playback.test.js
+++ b/tests/content/playback.test.js
@@ -1,0 +1,133 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  monitorVideoElement,
+  resolveTrackedVideo,
+  computePlaybackState,
+  contentMessageListener,
+  MESSAGE_TYPES,
+  PLAYBACK_STATES,
+  __testInternals
+} from "../../src/content.js";
+import { clearDom } from "./dom.fixtures.js";
+
+describe("content playback helpers", () => {
+  beforeEach(() => {
+    clearDom();
+    __testInternals.trackedVideo = null;
+    globalThis.browser.runtime.sendMessage.mockClear();
+  });
+
+  it("monitors video playback events and updates state", async () => {
+    const video = document.createElement("video");
+    document.body.append(video);
+    let endedState = false;
+    Object.defineProperty(video, "ended", {
+      configurable: true,
+      get: () => endedState,
+      set: (value) => {
+        endedState = value;
+      }
+    });
+
+    monitorVideoElement(video);
+
+    const initialCall = globalThis.browser.runtime.sendMessage.mock.calls.at(-1);
+    expect(initialCall[0]).toMatchObject({
+      type: MESSAGE_TYPES.UPDATE_PLAYBACK_STATE,
+      payload: { state: PLAYBACK_STATES.PAUSED }
+    });
+
+    video.dispatchEvent(new Event("play"));
+    await Promise.resolve();
+    const afterPlay = globalThis.browser.runtime.sendMessage.mock.calls.at(-1);
+    expect(afterPlay[0]).toMatchObject({
+      payload: { state: PLAYBACK_STATES.PLAYING }
+    });
+
+    video.ended = true;
+    video.dispatchEvent(new Event("pause"));
+    await Promise.resolve();
+    const afterPause = globalThis.browser.runtime.sendMessage.mock.calls.at(-1);
+    expect(afterPause[0]).toMatchObject({
+      payload: { state: PLAYBACK_STATES.ENDED }
+    });
+  });
+
+  it("resolves tracked videos when present or falls back to DOM lookup", () => {
+    const video = document.createElement("video");
+    document.body.append(video);
+    monitorVideoElement(video);
+
+    expect(resolveTrackedVideo()).toBe(video);
+
+    video.remove();
+    expect(resolveTrackedVideo()).toBeNull();
+  });
+
+  it("derives playback states from video properties", () => {
+    expect(computePlaybackState(null)).toBe(PLAYBACK_STATES.IDLE);
+    expect(computePlaybackState({ ended: true })).toBe(PLAYBACK_STATES.ENDED);
+    expect(computePlaybackState({ paused: true })).toBe(PLAYBACK_STATES.PAUSED);
+    expect(computePlaybackState({ paused: false, ended: false })).toBe(PLAYBACK_STATES.PLAYING);
+  });
+
+  it("handles CONTROL_PLAYBACK messages for play and pause", async () => {
+    const video = document.createElement("video");
+    document.body.append(video);
+    let pausedState = true;
+    Object.defineProperty(video, "paused", {
+      configurable: true,
+      get: () => pausedState,
+      set: (value) => {
+        pausedState = value;
+      }
+    });
+    video.play = vi.fn(() => {
+      video.paused = false;
+      return Promise.resolve();
+    });
+    video.pause = vi.fn(() => {
+      video.paused = true;
+    });
+    monitorVideoElement(video);
+
+    const sendResponse = vi.fn();
+    const result = contentMessageListener(
+      { type: MESSAGE_TYPES.CONTROL_PLAYBACK, payload: { action: "play" } },
+      {},
+      sendResponse
+    );
+    expect(result).toBe(true);
+
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(sendResponse).toHaveBeenCalledWith({ success: true, state: PLAYBACK_STATES.PLAYING });
+    expect(video.play).toHaveBeenCalled();
+
+    const pauseResponse = vi.fn();
+    const pauseResult = contentMessageListener(
+      { type: MESSAGE_TYPES.CONTROL_PLAYBACK, payload: { action: "pause" } },
+      {},
+      pauseResponse
+    );
+    expect(pauseResult).toBe(false);
+    expect(video.pause).toHaveBeenCalled();
+    expect(pauseResponse).toHaveBeenCalledWith({ success: true, state: PLAYBACK_STATES.PAUSED });
+  });
+
+  it("responds with failure when playback control cannot locate a video", () => {
+    const sendResponse = vi.fn();
+    __testInternals.trackedVideo = null;
+
+    const result = contentMessageListener(
+      { type: MESSAGE_TYPES.CONTROL_PLAYBACK, payload: { action: "play" } },
+      {},
+      sendResponse
+    );
+
+    expect(result).toBe(false);
+    expect(sendResponse).toHaveBeenCalledWith({ success: false });
+  });
+});
+


### PR DESCRIPTION
## Summary
- export the content script helper functions and wrap runtime wiring in a new initContent entry point
- add DOM fixtures for episode cards and audio menus to support jsdom-based testing
- create menu, playback, and audio language content tests that exercise annotation, playback control, and language directives

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e325ab70a08323b5ae9f46d03c5c61