### PR TITLE
Refactor options module and add tests

### DIFF
--- a/src/options.js
+++ b/src/options.js
@@ -14,14 +14,22 @@ let state = {
   lastUpdated: Date.now()
 };
 
-const autoRemoveCheckbox = document.getElementById('auto-remove');
-const debugLoggingCheckbox = document.getElementById('debug-logging');
-const audioLanguageSelect = document.getElementById('audio-language');
-const clearQueueButton = document.getElementById('clear-queue');
-const exportQueueButton = document.getElementById('export-queue');
-const importQueueButton = document.getElementById('import-queue');
-const queueFileInput = document.getElementById('queue-file');
-const stateDumpEl = document.getElementById('state-dump');
+let activeDocument = typeof document !== 'undefined' ? document : null;
+
+const elements = {
+  autoRemoveCheckbox: null,
+  debugLoggingCheckbox: null,
+  audioLanguageSelect: null,
+  clearQueueButton: null,
+  exportQueueButton: null,
+  importQueueButton: null,
+  queueFileInput: null,
+  stateDumpEl: null
+};
+
+let messageSender = null;
+let confirmImpl = null;
+let alertImpl = null;
 
 const sendMessage = (message) => {
   return new Promise((resolve, reject) => {
@@ -61,113 +69,223 @@ const sendMessage = (message) => {
   });
 };
 
-const populateLanguages = () => {
-  AUDIO_LANGUAGES.forEach((language) => {
-    const option = document.createElement('option');
+const ensureDocument = () => {
+  if (!activeDocument) {
+    throw new Error('Document is not available. Did you forget to call initOptions?');
+  }
+  return activeDocument;
+};
+
+const getMessageSender = () => messageSender ?? sendMessage;
+
+const getConfirm = () => {
+  if (confirmImpl) {
+    return confirmImpl;
+  }
+  const globalConfirm = typeof globalThis.confirm === 'function' ? globalThis.confirm : null;
+  return globalConfirm ?? (() => true);
+};
+
+const getAlert = () => {
+  if (alertImpl) {
+    return alertImpl;
+  }
+  const globalAlert = typeof globalThis.alert === 'function' ? globalThis.alert : null;
+  return globalAlert ?? (() => undefined);
+};
+
+export const populateLanguages = (
+  languages = AUDIO_LANGUAGES,
+  select = elements.audioLanguageSelect
+) => {
+  if (!select) {
+    throw new Error('Audio language select element is not available');
+  }
+  select.innerHTML = '';
+  languages.forEach((language) => {
+    const option = ensureDocument().createElement('option');
     option.value = language.code;
     option.textContent = `${language.label} (${language.code})`;
-    audioLanguageSelect.appendChild(option);
+    select.appendChild(option);
   });
+  return select;
 };
 
-const renderState = () => {
-  autoRemoveCheckbox.checked = state.settings.autoRemoveCompleted;
-  debugLoggingCheckbox.checked = state.settings.debugLogging;
-  audioLanguageSelect.value = state.settings.defaultAudioLanguage;
-  stateDumpEl.textContent = JSON.stringify(state, null, 2);
-};
-
-const requestState = async () => {
-  const newState = await sendMessage({ type: MESSAGE_TYPES.GET_STATE });
-  if (newState) {
-    state = newState;
-    renderState();
+export const renderState = (nextState = state) => {
+  state = nextState;
+  if (elements.autoRemoveCheckbox) {
+    elements.autoRemoveCheckbox.checked = Boolean(state.settings.autoRemoveCompleted);
   }
+  if (elements.debugLoggingCheckbox) {
+    elements.debugLoggingCheckbox.checked = Boolean(state.settings.debugLogging);
+  }
+  if (elements.audioLanguageSelect) {
+    elements.audioLanguageSelect.value = state.settings.defaultAudioLanguage;
+  }
+  if (elements.stateDumpEl) {
+    elements.stateDumpEl.textContent = JSON.stringify(state, null, 2);
+  }
+  return state;
 };
 
-autoRemoveCheckbox.addEventListener('change', () => {
-  sendMessage({
-    type: MESSAGE_TYPES.UPDATE_SETTINGS,
-    payload: { settings: { autoRemoveCompleted: autoRemoveCheckbox.checked } }
-  });
-});
+export const requestState = async (sender = getMessageSender()) => {
+  const newState = await sender({ type: MESSAGE_TYPES.GET_STATE });
+  if (newState) {
+    renderState(newState);
+  }
+  return newState;
+};
 
-debugLoggingCheckbox.addEventListener('change', () => {
-  sendMessage({
-    type: MESSAGE_TYPES.UPDATE_SETTINGS,
-    payload: { settings: { debugLogging: debugLoggingCheckbox.checked } }
-  });
-});
+export const downloadJson = (filename, data, doc = ensureDocument()) => {
+  const blob = new Blob([JSON.stringify(data, null, 2)], { type: 'application/json' });
+  const url = URL.createObjectURL(blob);
+  const anchor = doc.createElement('a');
+  anchor.href = url;
+  anchor.download = filename;
+  doc.body.appendChild(anchor);
+  anchor.click();
+  anchor.remove();
+  URL.revokeObjectURL(url);
+  return anchor;
+};
 
-audioLanguageSelect.addEventListener('change', () => {
-  sendMessage({
+const handleAutoRemoveChange = () => {
+  const checkbox = elements.autoRemoveCheckbox;
+  if (!checkbox) {
+    return;
+  }
+  getMessageSender()({
     type: MESSAGE_TYPES.UPDATE_SETTINGS,
-    payload: { settings: { defaultAudioLanguage: audioLanguageSelect.value } }
+    payload: { settings: { autoRemoveCompleted: checkbox.checked } }
   });
-});
+};
 
-clearQueueButton.addEventListener('click', () => {
-  if (confirm('Clear the entire queue?')) {
-    sendMessage({
+const handleDebugLoggingChange = () => {
+  const checkbox = elements.debugLoggingCheckbox;
+  if (!checkbox) {
+    return;
+  }
+  getMessageSender()({
+    type: MESSAGE_TYPES.UPDATE_SETTINGS,
+    payload: { settings: { debugLogging: checkbox.checked } }
+  });
+};
+
+const handleAudioLanguageChange = () => {
+  const select = elements.audioLanguageSelect;
+  if (!select) {
+    return;
+  }
+  getMessageSender()({
+    type: MESSAGE_TYPES.UPDATE_SETTINGS,
+    payload: { settings: { defaultAudioLanguage: select.value } }
+  });
+};
+
+const handleClearQueue = () => {
+  if (getConfirm()('Clear the entire queue?')) {
+    getMessageSender()({
       type: MESSAGE_TYPES.SET_QUEUE,
       payload: { queue: [] }
     });
   }
-});
-
-const downloadJson = (filename, data) => {
-  const blob = new Blob([JSON.stringify(data, null, 2)], { type: 'application/json' });
-  const url = URL.createObjectURL(blob);
-  const anchor = document.createElement('a');
-  anchor.href = url;
-  anchor.download = filename;
-  document.body.appendChild(anchor);
-  anchor.click();
-  anchor.remove();
-  URL.revokeObjectURL(url);
 };
 
-exportQueueButton.addEventListener('click', async () => {
-  const currentState = await sendMessage({ type: MESSAGE_TYPES.GET_STATE });
+const handleExportQueue = async () => {
+  const currentState = await getMessageSender()({ type: MESSAGE_TYPES.GET_STATE });
   if (currentState) {
     downloadJson(`rollqueue-export-${Date.now()}.json`, currentState.queue);
   }
-});
+};
 
-importQueueButton.addEventListener('click', () => {
-  queueFileInput.click();
-});
-
-queueFileInput.addEventListener('change', async () => {
-  const [file] = queueFileInput.files;
+const handleImportQueue = async () => {
+  const input = elements.queueFileInput;
+  if (!input) {
+    return;
+  }
+  const [file] = input.files || [];
   if (!file) {
     return;
   }
-  const text = await file.text();
   try {
+    const text = await file.text();
     const data = JSON.parse(text);
     if (!Array.isArray(data)) {
       throw new Error('Invalid queue format');
     }
-    await sendMessage({
+    await getMessageSender()({
       type: MESSAGE_TYPES.SET_QUEUE,
       payload: { queue: data }
     });
-    alert('Queue imported successfully');
+    getAlert()('Queue imported successfully');
   } catch (error) {
     console.error('Failed to import queue', error);
-    alert('Failed to import queue. Please make sure the file is valid.');
+    getAlert()('Failed to import queue. Please make sure the file is valid.');
   } finally {
-    queueFileInput.value = '';
+    input.value = '';
   }
-});
+};
 
-browserApi.runtime.onMessage.addListener((message) => {
-  if (message.type === MESSAGE_TYPES.STATE_UPDATED) {
-    state = message.payload;
-    renderState();
+const handleImportClick = () => {
+  const input = elements.queueFileInput;
+  if (input) {
+    input.click();
   }
-});
+};
 
-populateLanguages();
-requestState();
+const handleRuntimeMessage = (message) => {
+  if (message?.type === MESSAGE_TYPES.STATE_UPDATED) {
+    renderState(message.payload);
+  }
+};
+
+const assignElements = (doc) => {
+  elements.autoRemoveCheckbox = doc.getElementById('auto-remove');
+  elements.debugLoggingCheckbox = doc.getElementById('debug-logging');
+  elements.audioLanguageSelect = doc.getElementById('audio-language');
+  elements.clearQueueButton = doc.getElementById('clear-queue');
+  elements.exportQueueButton = doc.getElementById('export-queue');
+  elements.importQueueButton = doc.getElementById('import-queue');
+  elements.queueFileInput = doc.getElementById('queue-file');
+  elements.stateDumpEl = doc.getElementById('state-dump');
+};
+
+let isInitialized = false;
+
+export const initOptions = ({
+  document: doc = typeof document !== 'undefined' ? document : null,
+  messageSender: customSender,
+  confirm: customConfirm,
+  alert: customAlert
+} = {}) => {
+  if (!doc) {
+    throw new Error('A document instance is required to initialize options');
+  }
+  activeDocument = doc;
+  assignElements(doc);
+  messageSender = customSender ?? sendMessage;
+  confirmImpl = customConfirm ?? null;
+  alertImpl = customAlert ?? null;
+
+  if (!isInitialized) {
+    elements.autoRemoveCheckbox?.addEventListener('change', handleAutoRemoveChange);
+    elements.debugLoggingCheckbox?.addEventListener('change', handleDebugLoggingChange);
+    elements.audioLanguageSelect?.addEventListener('change', handleAudioLanguageChange);
+    elements.clearQueueButton?.addEventListener('click', handleClearQueue);
+    elements.exportQueueButton?.addEventListener('click', handleExportQueue);
+    elements.importQueueButton?.addEventListener('click', handleImportClick);
+    elements.queueFileInput?.addEventListener('change', handleImportQueue);
+
+    if (browserApi?.runtime?.onMessage?.addListener) {
+      browserApi.runtime.onMessage.addListener(handleRuntimeMessage);
+    }
+
+    isInitialized = true;
+  }
+
+  populateLanguages();
+  renderState(state);
+  return requestState();
+};
+
+export const __getInternalState = () => state;

--- a/tests/options/import-export.test.js
+++ b/tests/options/import-export.test.js
@@ -1,0 +1,106 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { setupOptionsDom } from './setup.js';
+import { MESSAGE_TYPES, DEFAULT_SETTINGS } from '../../src/constants.js';
+
+describe('options import/export helpers', () => {
+  let document;
+  let elements;
+  let initOptions;
+  let downloadJson;
+
+  beforeEach(async () => {
+    ({ document, elements } = setupOptionsDom());
+    browser.runtime.onMessage.addListener.mockImplementation(() => {});
+    browser.runtime.sendMessage.__setHandler(async (message) => {
+      if (message.type === MESSAGE_TYPES.GET_STATE) {
+        return {
+          queue: [],
+          currentEpisodeId: null,
+          playbackState: 'idle',
+          settings: { ...DEFAULT_SETTINGS },
+          lastUpdated: Date.now()
+        };
+      }
+      return undefined;
+    });
+
+    const module = await import('../../src/options.js');
+    initOptions = module.initOptions;
+    downloadJson = module.downloadJson;
+    await initOptions({ document });
+  });
+
+  it('creates a temporary anchor to trigger JSON downloads', () => {
+    const clickSpy = vi.spyOn(window.HTMLAnchorElement.prototype, 'click');
+
+    downloadJson('export.json', { foo: 'bar' }, document);
+
+    expect(clickSpy).toHaveBeenCalledTimes(1);
+    expect(document.querySelectorAll('a[href^="blob:"]').length).toBe(0);
+    expect(URL.createObjectURL).toHaveBeenCalledTimes(1);
+    expect(URL.revokeObjectURL).toHaveBeenCalledTimes(1);
+
+    clickSpy.mockRestore();
+  });
+
+  it('imports a queue file and notifies the user on success', async () => {
+    const queueItems = [{ id: 'item-1' }, { id: 'item-2' }];
+    const file = {
+      text: vi.fn(() => Promise.resolve(JSON.stringify(queueItems)))
+    };
+
+    Object.defineProperty(elements.queueFileInput, 'files', {
+      configurable: true,
+      value: [file]
+    });
+
+    elements.queueFileInput.dispatchEvent(new window.Event('change'));
+
+    await Promise.resolve();
+    await Promise.all(
+      browser.runtime.__calls.sendMessage.map((call) => call.promise.catch(() => undefined))
+    );
+
+    const setQueueCall = browser.runtime.sendMessage.mock.calls.find(
+      ([message]) => message.type === MESSAGE_TYPES.SET_QUEUE
+    );
+
+    expect(setQueueCall).toBeTruthy();
+    expect(setQueueCall[0].payload.queue).toEqual(queueItems);
+    expect(globalThis.alert).toHaveBeenCalledWith('Queue imported successfully');
+    expect(elements.queueFileInput.value).toBe('');
+  });
+
+  it('shows an error alert when imported JSON is invalid', async () => {
+    const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    const file = {
+      text: vi.fn(() => Promise.resolve('{"invalid":true}'))
+    };
+
+    Object.defineProperty(elements.queueFileInput, 'files', {
+      configurable: true,
+      value: [file]
+    });
+
+    elements.queueFileInput.dispatchEvent(new window.Event('change'));
+
+    await Promise.resolve();
+    await Promise.all(
+      browser.runtime.__calls.sendMessage.map((call) => call.promise.catch(() => undefined))
+    );
+
+    const setQueueCalls = browser.runtime.sendMessage.mock.calls.filter(
+      ([message]) => message.type === MESSAGE_TYPES.SET_QUEUE
+    );
+
+    expect(setQueueCalls).toHaveLength(0);
+    expect(globalThis.alert).toHaveBeenCalledWith(
+      'Failed to import queue. Please make sure the file is valid.'
+    );
+    expect(consoleErrorSpy).toHaveBeenCalled();
+    expect(elements.queueFileInput.value).toBe('');
+
+    consoleErrorSpy.mockRestore();
+  });
+});

--- a/tests/options/setup.js
+++ b/tests/options/setup.js
@@ -1,0 +1,50 @@
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, resolve } from 'node:path';
+import { JSDOM } from 'jsdom';
+import { vi } from 'vitest';
+
+const templateHtml = (() => {
+  const currentDir = dirname(fileURLToPath(import.meta.url));
+  const htmlPath = resolve(currentDir, '../../src/options.html');
+  const rawHtml = readFileSync(htmlPath, 'utf8');
+  return rawHtml.replace(/<script[^>]*src="options\.js"[^>]*><\/script>/i, '');
+})();
+
+export const setupOptionsDom = () => {
+  const dom = new JSDOM(templateHtml, {
+    url: 'http://localhost',
+    pretendToBeVisual: true
+  });
+  const { window } = dom;
+  const { document } = window;
+
+  globalThis.window = window;
+  globalThis.document = document;
+  globalThis.HTMLElement = window.HTMLElement;
+  globalThis.HTMLInputElement = window.HTMLInputElement;
+  globalThis.Event = window.Event;
+  globalThis.File = window.File;
+  globalThis.Blob = window.Blob;
+  globalThis.navigator = window.navigator;
+  globalThis.getComputedStyle = window.getComputedStyle.bind(window);
+  globalThis.confirm = vi.fn(() => true);
+  globalThis.alert = vi.fn();
+
+  window.URL.createObjectURL = vi.fn(() => 'blob:mock-url');
+  window.URL.revokeObjectURL = vi.fn();
+  globalThis.URL = window.URL;
+
+  const elements = {
+    autoRemoveCheckbox: document.getElementById('auto-remove'),
+    debugLoggingCheckbox: document.getElementById('debug-logging'),
+    audioLanguageSelect: document.getElementById('audio-language'),
+    clearQueueButton: document.getElementById('clear-queue'),
+    exportQueueButton: document.getElementById('export-queue'),
+    importQueueButton: document.getElementById('import-queue'),
+    queueFileInput: document.getElementById('queue-file'),
+    stateDumpEl: document.getElementById('state-dump')
+  };
+
+  return { dom, window, document, elements };
+};

--- a/tests/options/state.test.js
+++ b/tests/options/state.test.js
@@ -1,0 +1,113 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+import { setupOptionsDom } from './setup.js';
+import { AUDIO_LANGUAGES, DEFAULT_SETTINGS, MESSAGE_TYPES } from '../../src/constants.js';
+
+describe('options state rendering', () => {
+  let document;
+  let elements;
+  let initOptions;
+  let renderState;
+  let populateLanguages;
+  let runtimeListeners;
+
+  beforeEach(async () => {
+    ({ document, elements } = setupOptionsDom());
+    runtimeListeners = [];
+    browser.runtime.onMessage.addListener.mockImplementation((callback) => {
+      runtimeListeners.push(callback);
+    });
+    browser.runtime.sendMessage.__setHandler(async (message) => {
+      if (message.type === MESSAGE_TYPES.GET_STATE) {
+        return {
+          queue: [],
+          currentEpisodeId: null,
+          playbackState: 'idle',
+          settings: { ...DEFAULT_SETTINGS },
+          lastUpdated: Date.now()
+        };
+      }
+      return undefined;
+    });
+
+    const module = await import('../../src/options.js');
+    initOptions = module.initOptions;
+    renderState = module.renderState;
+    populateLanguages = module.populateLanguages;
+  });
+
+  it('populates audio language options during initialization', async () => {
+    await initOptions({ document });
+
+    const optionValues = Array.from(elements.audioLanguageSelect.options).map((option) => option.value);
+    const optionLabels = Array.from(elements.audioLanguageSelect.options).map((option) => option.textContent);
+
+    expect(optionValues).toEqual(AUDIO_LANGUAGES.map((language) => language.code));
+    expect(optionLabels).toEqual(
+      AUDIO_LANGUAGES.map((language) => `${language.label} (${language.code})`)
+    );
+  });
+
+  it('mirrors state values to controls and dump output', async () => {
+    await initOptions({ document });
+
+    const updatedState = {
+      queue: [{ id: 'episode-1' }],
+      currentEpisodeId: 'episode-1',
+      playbackState: 'playing',
+      settings: {
+        ...DEFAULT_SETTINGS,
+        autoRemoveCompleted: true,
+        debugLogging: true,
+        defaultAudioLanguage: AUDIO_LANGUAGES[1].code
+      },
+      lastUpdated: 123456789
+    };
+
+    renderState(updatedState);
+
+    expect(elements.autoRemoveCheckbox.checked).toBe(true);
+    expect(elements.debugLoggingCheckbox.checked).toBe(true);
+    expect(elements.audioLanguageSelect.value).toBe(updatedState.settings.defaultAudioLanguage);
+    expect(JSON.parse(elements.stateDumpEl.textContent)).toEqual(updatedState);
+  });
+
+  it('updates rendered state when receiving STATE_UPDATED runtime messages', async () => {
+    await initOptions({ document });
+
+    expect(runtimeListeners).toHaveLength(1);
+    const [listener] = runtimeListeners;
+
+    const broadcastState = {
+      queue: [{ id: 'ep-2' }],
+      currentEpisodeId: 'ep-2',
+      playbackState: 'paused',
+      settings: {
+        ...DEFAULT_SETTINGS,
+        autoRemoveCompleted: false,
+        debugLogging: true,
+        defaultAudioLanguage: AUDIO_LANGUAGES[2].code
+      },
+      lastUpdated: 987654321
+    };
+
+    listener({ type: MESSAGE_TYPES.STATE_UPDATED, payload: broadcastState });
+
+    expect(elements.debugLoggingCheckbox.checked).toBe(true);
+    expect(elements.autoRemoveCheckbox.checked).toBe(false);
+    expect(elements.audioLanguageSelect.value).toBe(broadcastState.settings.defaultAudioLanguage);
+    expect(JSON.parse(elements.stateDumpEl.textContent)).toEqual(broadcastState);
+  });
+
+  it('clears and repopulates languages when populateLanguages is called manually', async () => {
+    await initOptions({ document });
+
+    const select = elements.audioLanguageSelect;
+    select.appendChild(document.createElement('option')).value = 'extra';
+
+    populateLanguages();
+
+    expect(Array.from(select.options).map((option) => option.value)).toEqual(
+      AUDIO_LANGUAGES.map((language) => language.code)
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- refactor the options page script to expose helper functions and delay initialization until initOptions is called
- add shared jsdom setup for options tests and create suites covering state rendering and import/export flows

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e32bc780748323a1d3edda58796d0a