### PR TITLE
Add Firefox build workflow

### DIFF
--- a/.github/workflows/firefox-build.yml
+++ b/.github/workflows/firefox-build.yml
@@ -1,0 +1,36 @@
+name: Build Firefox Package
+
+on:
+  workflow_dispatch:
+  release:
+    types: [published]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build Firefox package
+        run: npm run build:firefox
+
+      - name: Zip Firefox extension
+        run: |
+          cd dist
+          zip -r firefox.zip firefox
+
+      - name: Upload Firefox artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: firefox-extension
+          path: dist/firefox.zip

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -1,0 +1,11 @@
+# Releasing RollQueue
+
+## Firefox builds
+
+A GitHub Actions workflow builds the Firefox package so that rasterized icons stay out of the repository.
+
+1. Trigger the **Build Firefox Package** workflow manually from the *Actions* tab or wait for it to run when a release is published.
+2. The workflow runs on Ubuntu with Node.js 20, executes `npm ci`, runs the Firefox build script to generate the PNG icons and manifest, and zips `dist/firefox/` into `dist/firefox.zip`.
+3. Download the `firefox-extension` artifact from the workflow run. The ZIP inside the artifact is what you upload to [addons.mozilla.org](https://addons.mozilla.org/).
+
+Because the PNG binaries are generated during the workflow, they never need to be committed to the repository.

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "rollqueue",
       "version": "1.0.0",
       "devDependencies": {
+        "@resvg/resvg-js": "^2.6.2",
         "@testing-library/dom": "^10.4.1",
         "@vitest/coverage-v8": "^3.2.4",
         "jsdom": "^27.0.0",
@@ -804,6 +805,234 @@
       "optional": true,
       "engines": {
         "node": ">=14"
+      }
+    },
+    "node_modules/@resvg/resvg-js": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@resvg/resvg-js/-/resvg-js-2.6.2.tgz",
+      "integrity": "sha512-xBaJish5OeGmniDj9cW5PRa/PtmuVU3ziqrbr5xJj901ZDN4TosrVaNZpEiLZAxdfnhAe7uQ7QFWfjPe9d9K2Q==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "engines": {
+        "node": ">= 10"
+      },
+      "optionalDependencies": {
+        "@resvg/resvg-js-android-arm-eabi": "2.6.2",
+        "@resvg/resvg-js-android-arm64": "2.6.2",
+        "@resvg/resvg-js-darwin-arm64": "2.6.2",
+        "@resvg/resvg-js-darwin-x64": "2.6.2",
+        "@resvg/resvg-js-linux-arm-gnueabihf": "2.6.2",
+        "@resvg/resvg-js-linux-arm64-gnu": "2.6.2",
+        "@resvg/resvg-js-linux-arm64-musl": "2.6.2",
+        "@resvg/resvg-js-linux-x64-gnu": "2.6.2",
+        "@resvg/resvg-js-linux-x64-musl": "2.6.2",
+        "@resvg/resvg-js-win32-arm64-msvc": "2.6.2",
+        "@resvg/resvg-js-win32-ia32-msvc": "2.6.2",
+        "@resvg/resvg-js-win32-x64-msvc": "2.6.2"
+      }
+    },
+    "node_modules/@resvg/resvg-js-android-arm-eabi": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@resvg/resvg-js-android-arm-eabi/-/resvg-js-android-arm-eabi-2.6.2.tgz",
+      "integrity": "sha512-FrJibrAk6v29eabIPgcTUMPXiEz8ssrAk7TXxsiZzww9UTQ1Z5KAbFJs+Z0Ez+VZTYgnE5IQJqBcoSiMebtPHA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@resvg/resvg-js-android-arm64": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@resvg/resvg-js-android-arm64/-/resvg-js-android-arm64-2.6.2.tgz",
+      "integrity": "sha512-VcOKezEhm2VqzXpcIJoITuvUS/fcjIw5NA/w3tjzWyzmvoCdd+QXIqy3FBGulWdClvp4g+IfUemigrkLThSjAQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@resvg/resvg-js-darwin-arm64": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@resvg/resvg-js-darwin-arm64/-/resvg-js-darwin-arm64-2.6.2.tgz",
+      "integrity": "sha512-nmok2LnAd6nLUKI16aEB9ydMC6Lidiiq2m1nEBDR1LaaP7FGs4AJ90qDraxX+CWlVuRlvNjyYJTNv8qFjtL9+A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@resvg/resvg-js-darwin-x64": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@resvg/resvg-js-darwin-x64/-/resvg-js-darwin-x64-2.6.2.tgz",
+      "integrity": "sha512-GInyZLjgWDfsVT6+SHxQVRwNzV0AuA1uqGsOAW+0th56J7Nh6bHHKXHBWzUrihxMetcFDmQMAX1tZ1fZDYSRsw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@resvg/resvg-js-linux-arm-gnueabihf": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@resvg/resvg-js-linux-arm-gnueabihf/-/resvg-js-linux-arm-gnueabihf-2.6.2.tgz",
+      "integrity": "sha512-YIV3u/R9zJbpqTTNwTZM5/ocWetDKGsro0SWp70eGEM9eV2MerWyBRZnQIgzU3YBnSBQ1RcxRZvY/UxwESfZIw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@resvg/resvg-js-linux-arm64-gnu": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@resvg/resvg-js-linux-arm64-gnu/-/resvg-js-linux-arm64-gnu-2.6.2.tgz",
+      "integrity": "sha512-zc2BlJSim7YR4FZDQ8OUoJg5holYzdiYMeobb9pJuGDidGL9KZUv7SbiD4E8oZogtYY42UZEap7dqkkYuA91pg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@resvg/resvg-js-linux-arm64-musl": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@resvg/resvg-js-linux-arm64-musl/-/resvg-js-linux-arm64-musl-2.6.2.tgz",
+      "integrity": "sha512-3h3dLPWNgSsD4lQBJPb4f+kvdOSJHa5PjTYVsWHxLUzH4IFTJUAnmuWpw4KqyQ3NA5QCyhw4TWgxk3jRkQxEKg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@resvg/resvg-js-linux-x64-gnu": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@resvg/resvg-js-linux-x64-gnu/-/resvg-js-linux-x64-gnu-2.6.2.tgz",
+      "integrity": "sha512-IVUe+ckIerA7xMZ50duAZzwf1U7khQe2E0QpUxu5MBJNao5RqC0zwV/Zm965vw6D3gGFUl7j4m+oJjubBVoftw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@resvg/resvg-js-linux-x64-musl": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@resvg/resvg-js-linux-x64-musl/-/resvg-js-linux-x64-musl-2.6.2.tgz",
+      "integrity": "sha512-UOf83vqTzoYQO9SZ0fPl2ZIFtNIz/Rr/y+7X8XRX1ZnBYsQ/tTb+cj9TE+KHOdmlTFBxhYzVkP2lRByCzqi4jQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@resvg/resvg-js-win32-arm64-msvc": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@resvg/resvg-js-win32-arm64-msvc/-/resvg-js-win32-arm64-msvc-2.6.2.tgz",
+      "integrity": "sha512-7C/RSgCa+7vqZ7qAbItfiaAWhyRSoD4l4BQAbVDqRRsRgY+S+hgS3in0Rxr7IorKUpGE69X48q6/nOAuTJQxeQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@resvg/resvg-js-win32-ia32-msvc": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@resvg/resvg-js-win32-ia32-msvc/-/resvg-js-win32-ia32-msvc-2.6.2.tgz",
+      "integrity": "sha512-har4aPAlvjnLcil40AC77YDIk6loMawuJwFINEM7n0pZviwMkMvjb2W5ZirsNOZY4aDbo5tLx0wNMREp5Brk+w==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@resvg/resvg-js-win32-x64-msvc": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@resvg/resvg-js-win32-x64-msvc/-/resvg-js-win32-x64-msvc-2.6.2.tgz",
+      "integrity": "sha512-ZXtYhtUr5SSaBrUDq7DiyjOFJqBVL/dOBN7N/qmi/pO0IgiWW/f/ue3nbvu9joWE5aAKDoIzy/CxsY0suwGosQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
       }
     },
     "node_modules/@rollup/rollup-android-arm-eabi": {

--- a/package.json
+++ b/package.json
@@ -6,9 +6,12 @@
   "scripts": {
     "test": "vitest run",
     "test:watch": "vitest",
-    "test:coverage": "vitest run --coverage"
+    "test:coverage": "vitest run --coverage",
+    "build:firefox": "node scripts/build-firefox.mjs",
+    "package:firefox": "npm run build:firefox && cd dist && zip -r firefox.zip firefox"
   },
   "devDependencies": {
+    "@resvg/resvg-js": "^2.6.2",
     "@testing-library/dom": "^10.4.1",
     "@vitest/coverage-v8": "^3.2.4",
     "jsdom": "^27.0.0",

--- a/scripts/build-firefox.mjs
+++ b/scripts/build-firefox.mjs
@@ -1,0 +1,110 @@
+#!/usr/bin/env node
+import { promises as fs } from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+import { Resvg } from '@resvg/resvg-js';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const rootDir = path.resolve(__dirname, '..');
+const assetsDir = path.join(rootDir, 'assets');
+const distDir = path.join(rootDir, 'dist', 'firefox');
+const distAssetsDir = path.join(distDir, 'assets');
+
+await fs.rm(distDir, { recursive: true, force: true });
+await fs.mkdir(distAssetsDir, { recursive: true });
+
+const svgFiles = (await fs.readdir(assetsDir)).filter((file) => file.endsWith('.svg'));
+const renderedIconMap = new Map();
+
+for (const file of svgFiles) {
+  const sourcePath = path.join(assetsDir, file);
+  const svgContent = await fs.readFile(sourcePath);
+  const baseName = path.parse(file).name;
+  const manifestPathKey = path.posix.join('assets', file);
+  const sizeMap = new Map();
+
+  for (const size of [48, 128]) {
+    const resvg = new Resvg(svgContent, {
+      fitTo: {
+        mode: 'width',
+        value: size,
+      },
+    });
+    const pngData = resvg.render();
+    const outputName = `${baseName}-${size}.png`;
+    const outputPath = path.join(distAssetsDir, outputName);
+    await fs.writeFile(outputPath, pngData.asPng());
+    sizeMap.set(String(size), path.posix.join('assets', outputName));
+  }
+
+  renderedIconMap.set(manifestPathKey, sizeMap);
+}
+
+for (const file of await fs.readdir(assetsDir)) {
+  if (!file.endsWith('.svg')) {
+    const srcPath = path.join(assetsDir, file);
+    const destPath = path.join(distAssetsDir, file);
+    await fs.cp(srcPath, destPath, { recursive: true });
+  }
+}
+
+const copyIfExists = async (relativePath) => {
+  const source = path.join(rootDir, relativePath);
+  try {
+    const stats = await fs.stat(source);
+    const destination = path.join(distDir, relativePath);
+    await fs.mkdir(path.dirname(destination), { recursive: true });
+    if (stats.isDirectory()) {
+      await fs.cp(source, destination, { recursive: true });
+    } else {
+      await fs.copyFile(source, destination);
+    }
+  } catch (error) {
+    if (error.code !== 'ENOENT') {
+      throw error;
+    }
+  }
+};
+
+await copyIfExists('src');
+await copyIfExists('LICENSE');
+
+const manifestPath = path.join(rootDir, 'manifest.json');
+const manifest = JSON.parse(await fs.readFile(manifestPath, 'utf8'));
+
+const toPngPath = (iconPath, size) => {
+  if (!iconPath) {
+    return iconPath;
+  }
+  const normalized = iconPath.replace(/\\/g, '/').replace(/^\.\//, '');
+  const mapping = renderedIconMap.get(normalized);
+  if (mapping && mapping.has(String(size))) {
+    return mapping.get(String(size));
+  }
+  const parsed = path.posix.parse(normalized);
+  return path.posix.join(parsed.dir, `${parsed.name}-${size}.png`);
+};
+
+if (manifest.icons) {
+  for (const [size, iconPath] of Object.entries(manifest.icons)) {
+    manifest.icons[size] = toPngPath(iconPath, size);
+  }
+}
+
+if (manifest.action && manifest.action.default_icon) {
+  if (typeof manifest.action.default_icon === 'string') {
+    manifest.action.default_icon = {
+      48: toPngPath(manifest.action.default_icon, 48),
+      128: toPngPath(manifest.action.default_icon, 128),
+    };
+  } else {
+    for (const [size, iconPath] of Object.entries(manifest.action.default_icon)) {
+      manifest.action.default_icon[size] = toPngPath(iconPath, size);
+    }
+  }
+}
+
+const firefoxManifestPath = path.join(distDir, 'manifest.json');
+await fs.mkdir(path.dirname(firefoxManifestPath), { recursive: true });
+await fs.writeFile(firefoxManifestPath, `${JSON.stringify(manifest, null, 2)}\n`, 'utf8');


### PR DESCRIPTION
## Summary
- add a Resvg-powered build script that rasterizes SVG icons and assembles the Firefox distribution
- add npm helpers and automation to build and package the Firefox extension, including a dedicated workflow
- document how contributors obtain the Firefox artifact when preparing AMO submissions

## Testing
- npm run build:firefox
- npm run package:firefox

------
https://chatgpt.com/codex/tasks/task_e_68e3411cba388323a4a15b13a20de7f5